### PR TITLE
Remove unnecessary parameter from AddOpenAIChatCompletion method

### DIFF
--- a/src/KoalaWiki/KernelFactory.cs
+++ b/src/KoalaWiki/KernelFactory.cs
@@ -20,7 +20,7 @@ public class KernelFactory
 
         kernelBuilder.Services.AddSerilog(Log.Logger);
 
-        kernelBuilder.AddOpenAIChatCompletion(model, new Uri(chatEndpoint), chatApiKey, "Koala-Wiki",
+        kernelBuilder.AddOpenAIChatCompletion(model, new Uri(chatEndpoint), chatApiKey,
             httpClient: new HttpClient(new KoalaHttpClientHandler()
             {
                 //添加重试试


### PR DESCRIPTION
This pull request makes a minor adjustment to the `KernelFactory.cs` file by modifying the parameters passed to the `AddOpenAIChatCompletion` method. Specifically, the `"Koala-Wiki"` string parameter has been removed.