### PR TITLE
新增文件上传限制配置，支持导出Markdown文件为ZIP格式；更新相关文档和API处理逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ services:
       - EnableSmartFilter=true # Whether intelligent filtering is enabled or not may affect how the AI can obtain the file directory of the repository
       - UPDATE_INTERVAL # Warehouse increment update interval, unit: days
       - PARALLEL_COUNT=1 # The warehouse processes the quantity in parallel
+      - MAX_FILE_LIMIT=100 # The maximum limit for uploading files, in MB
 ```
 
 AzureOpenAI:
@@ -96,6 +97,7 @@ services:
       - EnableSmartFilter=true # Whether intelligent filtering is enabled or not may affect how the AI can obtain the file directory of the repository
       - UPDATE_INTERVAL # Warehouse increment update interval, unit: days
       - PARALLEL_COUNT=1 # The warehouse processes the quantity in parallel
+      - MAX_FILE_LIMIT=100 # The maximum limit for uploading files, in MB
 ```
 
 Anthropic:
@@ -116,6 +118,7 @@ services:
       - EnableSmartFilter=true # Whether intelligent filtering is enabled or not may affect how the AI can obtain the file directory of the repository
       - UPDATE_INTERVAL # Warehouse increment update interval, unit: days
       - PARALLEL_COUNT=1 # The warehouse processes the quantity in parallel
+      - MAX_FILE_LIMIT=100 # The maximum limit for uploading files, in MB
 ```
 
 > 💡 **How to get an API Key:**
@@ -221,6 +224,7 @@ graph TD
   - EnableSmartFilter Whether intelligent filtering is enabled or not may affect how the AI can obtain the file directory of the repository
   - UPDATE_INTERVAL Warehouse increment update interval, unit: days
   - PARALLEL_COUNT The warehouse processes the quantity in parallel
+  - MAX_FILE_LIMIT The maximum limit for uploading files, in MB
 
 ### Build for Different Architectures
 The Makefile provides commands to build for different CPU architectures:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,6 +79,8 @@ services:
       - EnableSmartFilter=true # 是否启用智能过滤，这可能影响AI得到仓库的文件目录
       - UPDATE_INTERVAL=5 # 仓库增量更新间隔，单位天
       - PARALLEL_COUNT=1 # 仓库并行处理数量 
+      - MAX_FILE_LIMIT=100 # 上传文件的最大限制，单位MB
+
 ```
 
 AzureOpenAI
@@ -99,6 +101,7 @@ services:
       - EnableSmartFilter=true # 是否启用智能过滤，这可能影响AI得到仓库的文件目录
       - UPDATE_INTERVAL=5 # 仓库增量更新间隔，单位天
       - PARALLEL_COUNT=1 # 仓库并行处理数量 
+      - MAX_FILE_LIMIT=100 # 上传文件的最大限制，单位MB
 ```
 
 Anthropic
@@ -119,6 +122,7 @@ services:
       - EnableSmartFilter=true # 是否启用智能过滤，这可能影响AI得到仓库的文件目录
       - UPDATE_INTERVAL=5 # 仓库增量更新间隔，单位天
       - PARALLEL_COUNT=1 # 仓库并行处理数量 
+      - MAX_FILE_LIMIT=100 # 上传文件的最大限制，单位MB
 ```
 
 
@@ -225,6 +229,7 @@ graph TD
   - EnableSmartFilter 是否启用智能过滤，这可能影响AI得到仓库的文件目录
   - UPDATE_INTERVAL 仓库增量更新间隔，单位天
   - PARALLEL_COUNT 仓库并行处理数量
+  - MAX_FILE_LIMIT 上传文件的最大限制，单位MB
 
 ### 针对不同架构的构建
 Makefile提供了针对不同CPU架构构建的命令：

--- a/src/KoalaWiki/Options/OpenAIOptions.cs
+++ b/src/KoalaWiki/Options/OpenAIOptions.cs
@@ -15,6 +15,8 @@ public class OpenAIOptions
 
     public static string ModelProvider { get; set; } = string.Empty;
 
+    public static int MaxFileLimit { get; set; } = 10;
+
     public static void InitConfig(IConfiguration configuration)
     {
         ChatModel = (configuration.GetValue<string>("CHAT_MODEL") ??
@@ -27,6 +29,10 @@ public class OpenAIOptions
                     configuration.GetValue<string>("Endpoint") ?? string.Empty).GetTrimmedValueOrEmpty();
         ModelProvider = (configuration.GetValue<string>("MODEL_PROVIDER") ??
                          configuration.GetValue<string>("ModelProvider")).GetTrimmedValueOrEmpty();
+
+        MaxFileLimit = configuration.GetValue<int>("MAX_FILE_LIMIT") > 0
+            ? configuration.GetValue<int>("MAX_FILE_LIMIT")
+            : 10;
 
         if (string.IsNullOrEmpty(ModelProvider))
         {
@@ -54,6 +60,5 @@ public class OpenAIOptions
         {
             AnalysisModel = ChatModel;
         }
-        
     }
 }

--- a/src/KoalaWiki/Program.cs
+++ b/src/KoalaWiki/Program.cs
@@ -6,6 +6,7 @@ using KoalaWiki.MCP;
 using KoalaWiki.Options;
 using KoalaWiki.WarehouseProcessing;
 using Mapster;
+using Microsoft.AspNetCore.Http.Features;
 using Scalar.AspNetCore;
 using Serilog;
 
@@ -24,6 +25,16 @@ builder.Configuration.GetSection(DocumentOptions.Name)
 
 #endregion
 
+// 设置文件上传大小
+builder.Services.Configure<FormOptions>(options =>
+{
+    options.MultipartBodyLengthLimit = 1024 * 1024 * OpenAIOptions.MaxFileLimit; // 10MB
+});
+
+builder.WebHost.UseKestrel((options =>
+{
+    options.Limits.MaxRequestBodySize = 1024 * 1024 * OpenAIOptions.MaxFileLimit; // 10MB
+}));
 
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddKoalaMcp();

--- a/src/KoalaWiki/Services/DocumentCatalogService.cs
+++ b/src/KoalaWiki/Services/DocumentCatalogService.cs
@@ -63,6 +63,7 @@ public class DocumentCatalogService(IKoalaWikiContext dbAccess) : FastApi
             document?.Description,
             progress = documentCatalogs.Count(x => x.IsCompleted) * 100 / documentCatalogs.Count,
             git = warehouse.Address,
+            document?.WarehouseId,
             document?.LikeCount,
             document?.Status,
             document?.CommentCount,

--- a/web/app/[owner]/[name]/layout.client.tsx
+++ b/web/app/[owner]/[name]/layout.client.tsx
@@ -17,6 +17,8 @@ import {
   Collapse,
   Alert,
   Progress,
+  Input,
+  Dropdown,
 } from 'antd';
 import {
   HomeOutlined,
@@ -28,14 +30,19 @@ import {
   BookOutlined,
   RocketOutlined,
   GlobalOutlined,
-  BulbOutlined
+  BulbOutlined,
+  SearchOutlined,
+  DownloadOutlined,
+  SettingOutlined,
+  InfoCircleOutlined,
 } from '@ant-design/icons';
-import { PanelRightClose, PanelLeftClose } from 'lucide-react'
+import { PanelRightClose, PanelLeftClose, SaveAll } from 'lucide-react'
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import AIInputBar from '../../components/AIInputBar';
 import Image from 'next/image';
+import { ExportMarkdownZip } from '../../services';
 
 const { Header, Content, Footer } = Layout;
 const { Title, Text, Paragraph } = Typography;
@@ -529,30 +536,91 @@ export default function RepositoryLayoutClient({
               }}
             >
               <div className="sidebar-header" style={{
-                padding: `16px 0 8px`,
-                textAlign: 'right',
-                borderBottom: collapsed ? 'none' : '1px solid rgba(24, 144, 255, 0.05)',
-                display: collapsed ? 'none' : 'block',
+                padding: `12px 8px 12px`,
+                display: collapsed ? 'none' : 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                borderBottom: '1px solid rgba(24, 144, 255, 0.08)',
+                background: 'rgba(255, 255, 255, 0.97)',
+                backdropFilter: 'blur(8px)',
+                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.02)',
               }}>
-                <Button
-                  onClick={() => setCollapsed(true)}
-                  type='text'
-                  className="toggle-button sidebar-toggle"
-                  style={{
-                    background: 'none',
-                    border: 'none',
-                    cursor: 'pointer',
-                    padding: '4px 8px',
-                    marginRight: '12px',
-                    fontSize: '16px',
-                    color: token.colorPrimary,
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <PanelLeftClose />
-                </Button>
+                <div style={{
+                  display: 'flex',
+                  width: '100%',
+                  justifyContent: 'space-between', alignItems: 'center'
+                }}>
+                  <Button
+                    type="primary"
+                    size="small"
+                    icon={<SaveAll />}
+                    onClick={() =>
+                      Modal.confirm({
+                        title: '导出Markdown',
+                        content: '是否将当前文档导出为Markdown格式？',
+                        okText: '导出',
+                        cancelText: '取消',
+                        onOk: () => {
+                          ExportMarkdownZip(initialCatalogData.warehouseId)
+                            .then(response => {
+                              // 返回了blod
+                              if (response.success && response.data) {
+                                const blob = new Blob([response.data], { type: 'application/zip' });
+                                const url = URL.createObjectURL(blob);
+                                const a = document.createElement('a');
+                                a.href = url;
+                                a.download = `${owner}-${name}-docs.zip`;
+                                document.body.appendChild(a);
+                                a.click();
+                                document.body.removeChild(a);
+                                URL.revokeObjectURL(url);
+                              } else {
+                                message.error('导出失败，请稍后再试。');
+                              }
+                            })
+                        },
+                      })
+
+                    }
+                    style={{
+                      marginRight: '8px',
+                      background: 'linear-gradient(135deg, #1677ff 0%, #36acff 100%)',
+                      border: 'none',
+                      boxShadow: '0 2px 6px rgba(24, 144, 255, 0.25)',
+                      transition: 'all 0.3s ease',
+                      height: '32px',
+                      fontSize: '13px',
+                    }}
+                  >
+                    导出Markdown
+                  </Button>
+                  <Button
+                    onClick={() => setCollapsed(true)}
+                    type='text'
+                    className="toggle-button sidebar-toggle"
+                    style={{
+                      width: '32px',
+                      height: '32px',
+                      background: 'rgba(24, 144, 255, 0.05)',
+                      border: 'none',
+                      cursor: 'pointer',
+                      padding: 0,
+                      borderRadius: '4px',
+                      fontSize: '14px',
+                      color: token.colorPrimary,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      transition: 'background 0.2s ease',
+                      // @ts-ignore
+                      '&:hover': {
+                        background: 'rgba(24, 144, 255, 0.1)',
+                      }
+                    }}
+                  >
+                    <PanelLeftClose size={16} />
+                  </Button>
+                </div>
               </div>
 
               <div className={`menu-wrapper ${collapsed ? 'hidden' : ''}`}>
@@ -759,25 +827,27 @@ export default function RepositoryLayoutClient({
         }
       `}</style>
 
-      {initialCatalogData?.items?.length > 0 && (
-        <AIInputBar
-          owner={owner}
-          name={name}
-          style={{
-            position: 'fixed',
-            bottom: token.marginLG,
-            left: 0,
-            right: 0,
-            margin: '0 auto',
-            maxWidth: isMobile ? '80%' : '70%',
-            width: isMobile ? 'calc(100% - 32px)' : 'auto',
-            zIndex: 1001,
-            boxShadow: '0 4px 20px rgba(0, 0, 0, 0.1)',
-            borderRadius: 12,
-            backdropFilter: 'blur(16px)',
-          }}
-        />
-      )}
-    </ConfigProvider>
+      {
+        initialCatalogData?.items?.length > 0 && (
+          <AIInputBar
+            owner={owner}
+            name={name}
+            style={{
+              position: 'fixed',
+              bottom: token.marginLG,
+              left: 0,
+              right: 0,
+              margin: '0 auto',
+              maxWidth: isMobile ? '80%' : '70%',
+              width: isMobile ? 'calc(100% - 32px)' : 'auto',
+              zIndex: 1001,
+              boxShadow: '0 4px 20px rgba(0, 0, 0, 0.1)',
+              borderRadius: 12,
+              backdropFilter: 'blur(16px)',
+            }}
+          />
+        )
+      }
+    </ConfigProvider >
   );
-} 
+}

--- a/web/app/services/api.ts
+++ b/web/app/services/api.ts
@@ -83,7 +83,13 @@ async function clientFetchApi<T>(
       const data = await response.text();
       // @ts-ignore
       return { data, success: true, isSuccess: true };
-    } else {
+    }
+    // 导出Markdown文件为ZIP
+    else if (response.headers.get("content-type") === "application/zip") {
+      const data = await response.blob();
+      return { data, success: true, isSuccess: true };
+    }
+    else {
       const data = await response.json();
       return { data, success: true, isSuccess: true };
     }

--- a/web/app/services/warehouseService.ts
+++ b/web/app/services/warehouseService.ts
@@ -146,3 +146,13 @@ export async function UploadAndSubmitWarehouse(formData: FormData) {
   })
 }
 
+/**
+ * 导出仓库的Markdown文件为ZIP
+ * 此函数可在服务器组件中使用
+ * @param warehouseId 仓库ID
+ */
+export async function ExportMarkdownZip(warehouseId: string) {
+  return fetchApi<any>(API_URL + `/api/Warehouse/ExportMarkdownZip?warehouseId=${warehouseId}`, {
+    method: 'POST'
+  })
+}


### PR DESCRIPTION
This pull request introduces functionality to export warehouse documents as a Markdown ZIP file and sets a configurable maximum file upload size. The changes span backend, frontend, and documentation updates to support these features.

### Backend Changes:

* **Added Markdown Export Logic:**
  - Implemented the `ExportMarkdownZip` method in `WarehouseService` to generate and return a ZIP file containing Markdown files for all documents in a warehouse. This includes recursive handling of document catalogs. (`src/KoalaWiki/Services/WarehouseService.cs`, [src/KoalaWiki/Services/WarehouseService.csR391-R495](diffhunk://#diff-948616a30e37fe71084bfce70bb58db0b47dec6ef8ff01da54659d9ecffd0c41R391-R495))

* **Introduced `MaxFileLimit` Configuration:**
  - Added a `MaxFileLimit` property to `OpenAIOptions` and updated the `InitConfig` method to read its value from configuration. (`src/KoalaWiki/Options/OpenAIOptions.cs`, [[1]](diffhunk://#diff-8f537cc33c07b84c338b08f8296f046b50bcd2924e9a1b0cf0edf954df0ea27bR18-R19) [[2]](diffhunk://#diff-8f537cc33c07b84c338b08f8296f046b50bcd2924e9a1b0cf0edf954df0ea27bR33-R36)
  - Configured file upload size limits in `Program.cs` using the `MaxFileLimit` value. (`src/KoalaWiki/Program.cs`, [src/KoalaWiki/Program.csR28-R37](diffhunk://#diff-e78d307f24975dd41326f8348d4e598e065b969bcfeeafc6ee2d15f7b9789f7eR28-R37))

### Frontend Changes:

* **Export Markdown Button:**
  - Added a button in the repository layout (`layout.client.tsx`) to trigger the Markdown export feature. The button uses a modal for confirmation and downloads the ZIP file upon success. (`web/app/[owner]/[name]/layout.client.tsx`, [web/app/[owner]/[name]/layout.client.tsxL532-R624](diffhunk://#diff-7cde9483a2433a218c219d99ca4901d6c04c800285ab45fafd2d6ab6f24f195fL532-R624), [web/app/[owner]/[name]/layout.client.tsxL762-R831](diffhunk://#diff-7cde9483a2433a218c219d99ca4901d6c04c800285ab45fafd2d6ab6f24f195fL762-R831))

* **Client API Updates:**
  - Updated `clientFetchApi` to handle ZIP file responses and added a new `ExportMarkdownZip` service for triggering the export API. (`web/app/services/api.ts`, [[1]](diffhunk://#diff-d353241168d712635a13654ebd1f799af7f683516d37c1f7440e2a11109b07eeL86-R92); `web/app/services/warehouseService.ts`, [[2]](diffhunk://#diff-839711cb58b6a110974ea1b2cece6dfc468b62e9e085f2a6a77cd7eed7ae3ba3R149-R158)

### Documentation Updates:

* **Configurable Options:**
  - Documented the new `MAX_FILE_LIMIT` configuration in both English (`README.md`) and Chinese (`README.zh-CN.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R79) [[2]](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987R82-R83)

* **Graph Representation:**
  - Updated the `graph TD` sections in both documentation files to include `MAX_FILE_LIMIT`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R227) [[2]](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987R232)