### PR TITLE
提供了自定义后端API的功能

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,11 +2,9 @@ FROM --platform=$BUILDPLATFORM node:23-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
@@ -15,17 +13,11 @@ RUN \
   else echo "Lockfile not found." && exit 1; \
   fi
 
-
 # Rebuild the source code only when needed
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-
-# Next.js collects completely anonymous telemetry data about general usage.
-# Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry during the build.
-# ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN \
   if [ -f yarn.lock ]; then yarn run build; \
@@ -39,26 +31,29 @@ FROM base AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
-# Uncomment the following line in case you want to disable telemetry during runtime.
-# ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-COPY --from=builder /app/public ./public
+# 安装 sed 工具用于文本替换
+RUN apk add --no-cache sed
 
-# Automatically leverage output traces to reduce image size
-# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+# 复制启动脚本
+COPY start.sh /app/start.sh
+RUN chmod +x /app/start.sh
+
+# 改变所有权到 nextjs 用户
+RUN chown -R nextjs:nodejs /app
 
 USER nextjs
 
 EXPOSE 3000
-
 ENV PORT=3000
-
-# server.js is created by next build from the standalone output
-# https://nextjs.org/docs/pages/api-reference/config/next-config-js/output
 ENV HOSTNAME="0.0.0.0"
-CMD ["node", "server.js"]
+
+# 使用启动脚本而不是直接启动 server.js
+CMD ["/app/start.sh"]

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -4,13 +4,15 @@ const nextConfig = {
   reactStrictMode: true,  
   transpilePackages: ['antd','@ant-design/icons'],
   async rewrites() {
+    // 使用占位符，在运行时会被替换
+    const apiUrl = 'http://__API_URL_PLACEHOLDER__';
     return [
       {
         source: '/api/:path*',
-        destination: `${process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5085' }/api/:path*`,
+        destination: `${apiUrl}/api/:path*`,
       },
     ];
   },
 };
 
-module.exports = nextConfig; 
+module.exports = nextConfig;

--- a/web/start.sh
+++ b/web/start.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -x
+
+# 设置默认API URL
+DEFAULT_API_URL="http://localhost:5085"
+API_URL="${API_URL:-$DEFAULT_API_URL}"
+
+echo "Starting application with API_URL: $API_URL"
+
+# 如果API_URL不是默认值，则进行替换
+if [ "$API_URL" != "http://__API_URL_PLACEHOLDER__" ]; then
+    echo "Replacing API URL placeholder with: $API_URL"
+    
+    # 替换 .next 目录下所有 JavaScript 文件中的占位符
+    find /app/.next -name "*.js" -type f -exec sed -i "s|http://__API_URL_PLACEHOLDER__|$API_URL|g" {} \;
+    find /app/.next -name "*.json" -type f -exec sed -i "s|http://__API_URL_PLACEHOLDER__|$API_URL|g" {} \;
+    
+    # 替换服务端渲染文件中的占位符
+    find /app -name "server.js" -type f -exec sed -i "s|http://__API_URL_PLACEHOLDER__|$API_URL|g" {} \;
+    
+    # 创建客户端运行时配置
+    cat > /app/public/runtime-config.js << EOF
+window.__API_URL__ = '$API_URL';
+EOF
+    
+    echo "API URL replacement completed"
+else
+    echo "Using default API URL configuration"
+fi
+
+# 启动Next.js应用
+echo "Starting Next.js server..."
+exec node server.js


### PR DESCRIPTION
#88 
修改了三个文件：

1. web/Dockerfile：增加启动脚本，在容器启动时执行
2. web/next.config.js：将API默认写为占位符格式，方便后面进行查找和替换
3. web/start.sh：docker启动脚本，查找相应的形式为占位符的API，将其替换为环境变量API_URL中定义的API，如果没有使用环境变量，则默认为“http://localhost:5085”

有了上面的修改，我们就可以直接使用官方提供的镜像，使用环境变量来自定义后端API