### PR TITLE
修复branch和readme字段值互换问题

### DIFF
--- a/src/KoalaWiki/KoalaWarehouse/Overview/OverviewService.cs
+++ b/src/KoalaWiki/KoalaWarehouse/Overview/OverviewService.cs
@@ -47,8 +47,8 @@ public class OverviewService
                 {
                     ["catalogue"] = catalog,
                     ["git_repository"] = gitRepository.Replace(".git", ""),
-                    ["branch"] = readme,
-                    ["readme"] = branch
+                    ["branch"] = branch,
+                    ["readme"] = readme
                 });
         }
 


### PR DESCRIPTION
无意发现发给模型中的prompt里面branch和readme反了，该PR修复了这个问题。