### PR TITLE
添加支持从URL下载压缩包的功能，更新仓库表单以选择上传方式

### DIFF
--- a/web/app/types/index.ts
+++ b/web/app/types/index.ts
@@ -11,6 +11,8 @@ export interface RepositoryFormValues {
   submitType?: 'git' | 'upload'; // 提交方式：Git仓库或上传压缩包
   organization?: string;     // 组织名称 (上传压缩包时)
   repositoryName?: string;   // 仓库名称 (上传压缩包时)
+  uploadMethod?: 'file' | 'url'; // 上传方式：文件上传或URL下载
+  fileUrl?: string;          // 压缩包URL地址 (URL下载时)
 }
 
 /**


### PR DESCRIPTION
此请求引入了支持从 URL 下载压缩文件的功能，以替代直接上传文件。它包括对后端 (`WarehouseService.cs`) 和前端 (`RepositoryForm.tsx`)的更改，以启用此功能。最重要的更改是添加了一个从 URL 下载文件的方法，更新了后台处理新上传方法的功能，并修改了前台表单以允许用户在文件上传和 URL 下载之间进行选择。