### PR TITLE
优化CodeDirSimplifier提示词，使用“统计所有”替代“列出所有”，对小模型更友好

### DIFF
--- a/src/KoalaWiki/plugins/CodeAnalysis/CodeDirSimplifier/skprompt.txt
+++ b/src/KoalaWiki/plugins/CodeAnalysis/CodeDirSimplifier/skprompt.txt
@@ -22,10 +22,11 @@ Conduct a thorough analysis of the repository using the following steps. Wrap yo
    - Identify any deployment instructions or crucial setup information
 
 2. Project Type Identification:
-   - List all file extensions and their frequencies
-   - Analyze directory structure
-   - Determine primary programming language(s) and frameworks
-   - Provide reasoning for your conclusions
+   - Collect statistics for all file extensions and their frequency distribution
+   - Analyze directory structure patterns and organizational hierarchy
+   - Identify primary programming language(s), frameworks, and technologies based on extension analysis
+   - Map common file extensions to their corresponding technologies and development environments
+   - Provide evidence-based conclusions about the project type and technology stack
 
 3. Multi-stage Filtering:
    - List explicit documentation files (README, markdown, etc.)


### PR DESCRIPTION
### 效果对比

测试模型：`Qwen/Qwen3-30B-A3B`

- 新提示词
![image](https://github.com/user-attachments/assets/830b5de5-b1f8-4003-9bbb-a4a8a6e9d3cf)

- 旧提示词 （有一定概率，但不大）
![image](https://github.com/user-attachments/assets/5ae69a80-76c1-49f4-98d2-308dca580ce6)
