### PR TITLE
切换为官方源，修复`dotnet restore`出错。

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
-        <add key="nuget.cdn.com" value="https://nuget.cdn.azure.cn/v3/index.json" protocolVersion="3" />
+        <clear />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     </packageSources>
     <packageRestore>
         <add key="enabled" value="True" />

--- a/src/KoalaWiki/KoalaWarehouse/DocumentsService.cs
+++ b/src/KoalaWiki/KoalaWarehouse/DocumentsService.cs
@@ -293,7 +293,7 @@ public partial class DocumentsService
         }
 
         activity?.SetTag("processing_type", "ai_smart_filter");
-        Log.Logger.Information("开始优化目录结构（使用树形格式）");
+        Log.Logger.Information($"开始优化目录结构（使用{DocumentOptions.CatalogueFormat}格式）");
 
         var analysisModel = KernelFactory.GetKernel(OpenAIOptions.Endpoint,
             OpenAIOptions.ChatApiKey, path, OpenAIOptions.AnalysisModel);


### PR DESCRIPTION
除了此文件中的源之外，您的构建过程还在使用其他 NuGet 源（可能是全局 `NuGet.Config` 文件中定义的源）。当使用中央包管理时，拥有多个源而没有源映射会导致问题。

为了解决这两个问题，将修改 `NuGet.Config` 文件，以专门使用官方的 nuget.org 包源，并阻止继承其他源。这将确保一致性并解决包还原错误。