### PR TITLE
chore(launchSettings): 移除不必要的环境变量配置

### DIFF
--- a/src/KoalaWiki/Properties/launchSettings.json
+++ b/src/KoalaWiki/Properties/launchSettings.json
@@ -21,8 +21,7 @@
       "launchBrowser": false,
       "applicationUrl": "https://localhost:7065;http://localhost:5085",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "Urls": "https://localhost:7065;http://localhost:5085"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }


### PR DESCRIPTION
从配置中移除 `Urls` 环境变量。让VSCode调试更友好（启动调试时，导致多次占用端口冲突）