### PR TITLE
fix: 修复错误的对话区域层级

### DIFF
--- a/web/app/chat/index.tsx
+++ b/web/app/chat/index.tsx
@@ -52,8 +52,8 @@ interface ReferenceFile {
 
 // Tailwind CSS 类名常量
 const styles = {
-  floatingButton: "fixed bottom-6 right-6 w-12 h-12 rounded-full flex items-center justify-center shadow-lg z-[1000] transition-all duration-300 hover:scale-105 hover:shadow-xl",
-  chatContainer: "fixed bottom-6 right-6 w-[550px] h-[700px] bg-card rounded-lg shadow-xl z-[1001] flex flex-col overflow-hidden transition-all duration-300 border",
+  floatingButton: "fixed bottom-6 right-6 w-12 h-12 rounded-full flex items-center justify-center shadow-lg z-[10] transition-all duration-300 hover:scale-105 hover:shadow-xl",
+  chatContainer: "fixed bottom-6 right-6 w-[550px] h-[700px] bg-card rounded-lg shadow-xl z-[10] flex flex-col overflow-hidden transition-all duration-300 border",
   chatContainerMinimized: "h-[60px]",
   chatContainerMaximized: "w-[580px] h-full bottom-0 right-0",
   chatContainerEmbedded: "relative !bottom-auto !right-auto !w-full !h-full !rounded-none !shadow-none !border-none",


### PR DESCRIPTION
## 变更点
- 修改了一下右下角对话区域的 z-index 层级
- 修改前的情况:
<img width="593" height="190" alt="image" src="https://github.com/user-attachments/assets/c342425c-e92d-43d2-a298-78aac8df5807" />

- tooltip 的 z-index 只有 50

## 变更后
<img width="567" height="138" alt="image" src="https://github.com/user-attachments/assets/84ba19b9-fa50-4b2f-b47d-87ab940620da" />
