### PR TITLE
fix: 修复目录无法被正确定位的问题

### DIFF
--- a/web/app/components/renderMarkdown.tsx
+++ b/web/app/components/renderMarkdown.tsx
@@ -1,25 +1,24 @@
 import { TOCItemType } from "fumadocs-core/server";
-import ThemedMarkdown from './ThemedMarkdown';
-
+import ThemedMarkdown from "./ThemedMarkdown";
+import { ensureUniqueSlug, generateSlug } from "../utils/slug";
 
 interface RenderMarkdownResult {
     body: any;
-    toc: TOCItemType[]
+    toc: TOCItemType[];
 }
 
 // 手动解析markdown，提取标题作为TOC
 function extractTOC(markdown: string): TOCItemType[] {
     const toc: TOCItemType[] = [];
     const headingRegex = /^(#{1,6})\s+(.+)$/gm;
+    const existingSlugs = new Set<string>();
 
     let match;
     while ((match = headingRegex.exec(markdown)) !== null) {
         const level = match[1].length;
         const text = match[2].trim();
-        const slug = text
-            .toLowerCase()
-            .replace(/[^\w\s-]/g, '')
-            .replace(/\s+/g, '-');
+        const baseSlug = generateSlug(text);
+        const slug = ensureUniqueSlug(baseSlug, existingSlugs);
 
         toc.push({
             title: text,
@@ -31,15 +30,15 @@ function extractTOC(markdown: string): TOCItemType[] {
     return toc;
 }
 
-export default function RenderMarkdown(props: { markdown: string }): RenderMarkdownResult {
+export default function RenderMarkdown(props: {
+    markdown: string;
+}): RenderMarkdownResult {
     if (!props.markdown) return { body: <></>, toc: [] };
 
     try {
         const toc = extractTOC(props.markdown);
         return {
-            body: <ThemedMarkdown>
-                {props.markdown}
-            </ThemedMarkdown>,
+            body: <ThemedMarkdown>{props.markdown}</ThemedMarkdown>,
             toc: toc
         };
     } catch (error) {
@@ -51,3 +50,4 @@ export default function RenderMarkdown(props: { markdown: string }): RenderMarkd
         };
     }
 }
+


### PR DESCRIPTION
## 存在的问题
文档目录无法被点击
![20250807101932_rec_](https://github.com/user-attachments/assets/0bfe50c9-e873-413b-bc9f-4ee2b9cd4ebe)

## 定位问题
renderMarkdown extractTOC里生成的 slug 存在问题且与HeadingAnchors中使用的生成逻辑不同
HeadingAnchors:
<img width="1073" height="853" alt="image" src="https://github.com/user-attachments/assets/3dfb5271-a3fc-48e9-9970-99ff3a7614f5" />
extractTOC:
<img width="826" height="576" alt="image" src="https://github.com/user-attachments/assets/3f1eb994-2877-4cf2-afc8-7a78dd752476" />

## 修复后
![20250807102509_rec_](https://github.com/user-attachments/assets/8d25a6e9-cd2c-48db-b9ac-f948caf8f1bc)
