### PR TITLE
fix: 修复日文等特殊字符文档URL编码问题

### DIFF
--- a/src/KoalaWiki/Services/DocumentCatalogService.cs
+++ b/src/KoalaWiki/Services/DocumentCatalogService.cs
@@ -96,6 +96,9 @@ public class DocumentCatalogService(IKoalaWikiContext dbAccess) : FastApi
     public async Task GetDocumentByIdAsync(string owner, string name, string? branch,
         string path, string? languageCode, HttpContext httpContext)
     {
+        // URL解码，处理包含特殊字符（如日文字符）的路径
+        var decodedPath = System.Web.HttpUtility.UrlDecode(path);
+        
         // 先根据仓库名称和组织名称找到仓库
         var warehouse = await dbAccess.Warehouses
             .AsNoTracking()
@@ -112,7 +115,7 @@ public class DocumentCatalogService(IKoalaWikiContext dbAccess) : FastApi
         // 找到catalog
         var id = await dbAccess.DocumentCatalogs
             .AsNoTracking()
-            .Where(x => x.WarehouseId == warehouse.Id && x.Url == path && x.IsDeleted == false)
+            .Where(x => x.WarehouseId == warehouse.Id && x.Url == decodedPath && x.IsDeleted == false)
             .Select(x => x.Id)
             .FirstOrDefaultAsync();
 

--- a/web/app/[owner]/[name]/page.tsx
+++ b/web/app/[owner]/[name]/page.tsx
@@ -36,8 +36,8 @@ export default async function RepositoryPage({ params, searchParams }: any) {
     if (catalogResponse.success && catalogResponse.data?.items && catalogResponse.data.items.length > 0) {
       const firstMenuItem = catalogResponse.data.items[0]
       if (firstMenuItem?.url) {
-        // 重定向到第一个菜单项
-        redirect(`/${owner}/${name}/${firstMenuItem.url}`);
+        // 重定向到第一个菜单项，必须编码以避免日文等字符导致的redirect错误
+        redirect(`/${owner}/${name}/${encodeURIComponent(firstMenuItem.url)}`);
       }
     }
   } catch (error) {

--- a/web/app/services/warehouseService.ts
+++ b/web/app/services/warehouseService.ts
@@ -339,13 +339,13 @@ export async function getWarehouse(page: number, pageSize: number, keyword?: str
  * 此函数可在服务器组件中使用
  */
 export async function documentCatalog(organizationName: string, name: string, branch?: string, languageCode?: string): Promise<any> {
-  // 构建URL，如果branch存在则添加到查询参数中
-  let url = API_URL + '/api/DocumentCatalog/DocumentCatalogs?organizationName=' + organizationName + '&name=' + name;
+  // 构建URL，如果branch存在则添加到查询参数中，并确保所有参数都被正确编码以处理特殊字符
+  let url = API_URL + '/api/DocumentCatalog/DocumentCatalogs?organizationName=' + encodeURIComponent(organizationName) + '&name=' + encodeURIComponent(name);
   if (branch) {
-    url += '&branch=' + branch;
+    url += '&branch=' + encodeURIComponent(branch);
   }
   if (languageCode) {
-    url += '&languageCode=' + languageCode;
+    url += '&languageCode=' + encodeURIComponent(languageCode);
   }
   
   // @ts-ignore
@@ -361,13 +361,13 @@ export async function documentCatalog(organizationName: string, name: string, br
  * 此函数可在服务器组件中使用
  */
 export async function documentById(owner: string, name: string, path: string, branch?: string, languageCode?: string): Promise<any> {
-  // 构建URL，如果branch存在则添加到查询参数中
-  let url = API_URL + '/api/DocumentCatalog/DocumentById?owner=' + owner + '&name=' + name + '&path=' + path;
+  // 构建URL，如果branch存在则添加到查询参数中，并对除path外的参数进行编码（path在后端进行解码处理）
+  let url = API_URL + '/api/DocumentCatalog/DocumentById?owner=' + encodeURIComponent(owner) + '&name=' + encodeURIComponent(name) + '&path=' + path;
   if (branch) {
-    url += '&branch=' + branch;
+    url += '&branch=' + encodeURIComponent(branch);
   }
   if (languageCode) {
-    url += '&languageCode=' + languageCode;
+    url += '&languageCode=' + encodeURIComponent(languageCode);
   }
 
   // @ts-ignore


### PR DESCRIPTION
- 修复项目页面重定向时日文字符导致的redirect错误
- 在前端重定向时对URL进行编码处理
- 在后端DocumentCatalogService中对path参数进行解码
- 优化API调用中的URL参数编码策略
- 解决访问日文文档时的500错误和Invalid character in header异常

影响范围:
- web/app/[owner]/[name]/page.tsx: 重定向URL编码
- src/KoalaWiki/Services/DocumentCatalogService.cs: 添加URL解码逻辑
- web/app/services/warehouseService.ts: 优化API参数编码