### PR TITLE
fix(DocumentPendingService): 检查文件内容是否为空以防止继续往下执行

### DIFF
--- a/src/KoalaWiki/KoalaWarehouse/DocumentPending/DocumentPendingService.cs
+++ b/src/KoalaWiki/KoalaWarehouse/DocumentPending/DocumentPendingService.cs
@@ -67,7 +67,7 @@ public partial class DocumentPendingService
             {
                 var (catalog, fileItem, files) = await completedTask.ConfigureAwait(false);
 
-                if (fileItem == null)
+                if (fileItem == null || string.IsNullOrEmpty(fileItem.Content))
                 {
                     // 构建失败
                     Log.Logger.Error("处理仓库；{path} ,处理标题：{name} 失败:文件内容为空", path, catalog.Name);


### PR DESCRIPTION
当文件内容为空时会导致构建失败，增加对fileItem.Content的空检查以避免此问题