### PR TITLE
Switch to Channel-based message processing

### DIFF
--- a/src/OpenDeepWiki/Chat/Processing/ChatMessageProcessingWorker.cs
+++ b/src/OpenDeepWiki/Chat/Processing/ChatMessageProcessingWorker.cs
@@ -43,11 +43,13 @@ public class ChatMessageProcessingWorker : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _logger.LogInformation("消息处理 Worker 已启动，并发数: {Concurrency}", _options.MaxConcurrency);
+        var concurrency = Math.Max(1, _options.MaxConcurrency);
+
+        _logger.LogInformation("消息处理 Worker 已启动，并发数: {Concurrency}", concurrency);
 
         var producer = ProduceMessagesAsync(stoppingToken);
 
-        var consumers = Enumerable.Range(0, _options.MaxConcurrency)
+        var consumers = Enumerable.Range(0, concurrency)
             .Select(_ => ConsumeMessagesAsync(stoppingToken))
             .ToArray();
 


### PR DESCRIPTION
Replace manual SemaphoreSlim/task-list concurrency with a bounded Channel producer/consumer model. Adds System.Threading.Channels and a bounded channel (capacity 100, FullMode=Wait) as a shared buffer. Refactors ExecuteAsync to run a single producer that dequeues messages and writes to the channel, and MaxConcurrency consumer tasks that read from the channel and call ProcessMessageAsync. Completes the channel writer on shutdown and preserves message completion, retry and dead-letter handling. This simplifies concurrency control, provides backpressure, and cleans up task management and error handling.