### PR TITLE
fix(admin): send role IDs instead of names when updating user roles

### DIFF
--- a/web/app/admin/users/page.tsx
+++ b/web/app/admin/users/page.tsx
@@ -180,7 +180,11 @@ export default function AdminUsersPage() {
   };
 
   const openRolesDialog = (user: AdminUser) => {
-    setSelectedRoles(user.roles || []);
+    // Map role names to IDs since the API expects IDs
+    const roleIds = (user.roles || []).map(
+      (name) => roles.find((r) => r.name === name)?.id
+    ).filter(Boolean) as string[];
+    setSelectedRoles(roleIds);
     setShowRolesDialog(user);
   };
 
@@ -439,12 +443,12 @@ export default function AdminUsersPage() {
               <div key={role.id} className="flex items-center gap-2">
                 <Checkbox
                   id={role.id}
-                  checked={selectedRoles.includes(role.name)}
+                  checked={selectedRoles.includes(role.id)}
                   onCheckedChange={(checked) => {
                     if (checked) {
-                      setSelectedRoles([...selectedRoles, role.name]);
+                      setSelectedRoles([...selectedRoles, role.id]);
                     } else {
-                      setSelectedRoles(selectedRoles.filter((r) => r !== role.name));
+                      setSelectedRoles(selectedRoles.filter((r) => r !== role.id));
                     }
                   }}
                 />


### PR DESCRIPTION
## Bug

The admin user role assignment dialog (`web/app/admin/users/page.tsx`) sends role **names** (e.g. `"Admin"`, `"User"`) to the `PUT /api/admin/users/{id}/roles` endpoint, but the backend `AdminUserService.UpdateUserRolesAsync` expects role **IDs** (UUIDs) to create `UserRole` records with valid `RoleId` foreign keys.

This causes a `FOREIGN KEY constraint failed` error (SQLite) or equivalent error on PostgreSQL whenever an admin tries to save role assignments from the admin panel.

## Root Cause

In `openRolesDialog()`, `selectedRoles` is initialized with `user.roles` which contains role names. The checkbox `checked` state and `onCheckedChange` handler also use `role.name`. When `handleRolesUpdate()` calls `updateUserRoles(id, selectedRoles)`, it sends these names to the API which tries to use them as foreign keys into the `Roles` table.

```typescript
// Before (broken): tracks role names
setSelectedRoles(user.roles || []);                    // ["Admin", "User"]
checked={selectedRoles.includes(role.name)}            // compares names
setSelectedRoles([...selectedRoles, role.name]);       // stores names
await updateUserRoles(showRolesDialog.id, selectedRoles); // sends names as IDs
```

## Fix

Map role names to IDs when opening the dialog, and track IDs throughout:

```typescript
// After (fixed): tracks role IDs  
const roleIds = (user.roles || []).map(
  (name) => roles.find((r) => r.name === name)?.id
).filter(Boolean) as string[];
setSelectedRoles(roleIds);                             // ["87b1d02f-...", ...]
checked={selectedRoles.includes(role.id)}              // compares IDs
setSelectedRoles([...selectedRoles, role.id]);         // stores IDs
await updateUserRoles(showRolesDialog.id, selectedRoles); // sends valid IDs
```

## How to Reproduce

1. Log in as admin
2. Go to `/admin` > Users
3. Click the role assignment button on any user
4. Check/uncheck any role and click Save
5. Toast shows "Failed to update roles"
6. Backend logs: `SQLite Error 19: 'FOREIGN KEY constraint failed'`