### PR TITLE
fix(i18n): translate role seed descriptions from Chinese to English

### DIFF
--- a/src/OpenDeepWiki/Infrastructure/DbInitializer.cs
+++ b/src/OpenDeepWiki/Infrastructure/DbInitializer.cs
@@ -82,7 +82,7 @@ public static class DbInitializer
             {
                 Id = Guid.NewGuid().ToString(),
                 Name = "Admin",
-                Description = "系统管理员",
+                Description = "System Administrator",
                 IsActive = true,
                 IsSystemRole = true,
                 CreatedAt = DateTime.UtcNow
@@ -91,7 +91,7 @@ public static class DbInitializer
             {
                 Id = Guid.NewGuid().ToString(),
                 Name = "User",
-                Description = "普通用户",
+                Description = "Regular User",
                 IsActive = true,
                 IsSystemRole = true,
                 CreatedAt = DateTime.UtcNow


### PR DESCRIPTION
## Problem

The default role descriptions seeded by `DbInitializer.InitializeRolesAsync()` are hardcoded in Chinese:

- Admin: `系统管理员`
- User: `普通用户`

These descriptions are displayed in the admin panel role assignment dialog, which means non-Chinese-speaking users see untranslated text.

## Fix

Translated to English:

- Admin: `System Administrator`
- User: `Regular User`

**Note:** This only affects new installations. Existing databases retain their current descriptions.

## File Changed

`src/OpenDeepWiki/Infrastructure/DbInitializer.cs` - lines 85, 94