### PR TITLE
fix(i18n): translate hardcoded Chinese strings in admin repositories page

### DIFF
--- a/web/app/admin/repositories/page.tsx
+++ b/web/app/admin/repositories/page.tsx
@@ -323,32 +323,32 @@ export default function AdminRepositoriesPage() {
         <div className="grid gap-3 md:grid-cols-3">
           <Card className="p-3">
             <div className="mb-2 flex items-center justify-between text-xs text-muted-foreground">
-              <span>当前页完成率</span>
+              <span>Page Completion Rate</span>
               <span>{overview.completedRate}%</span>
             </div>
             <Progress value={overview.completedRate} className="h-2.5" />
             <p className="mt-2 text-xs text-muted-foreground">
-              完成 {overview.completedCount} / {overview.pageCount}，处理中 {overview.processingCount}
+              Completed {overview.completedCount} / {overview.pageCount}, Processing {overview.processingCount}
             </p>
           </Card>
           <Card className="p-3">
             <div className="mb-2 flex items-center justify-between text-xs text-muted-foreground">
-              <span>公开仓库占比</span>
+              <span>Public Repository Ratio</span>
               <span>{overview.publicRate}%</span>
             </div>
             <Progress value={overview.publicRate} className="h-2.5" />
             <p className="mt-2 text-xs text-muted-foreground">
-              失败仓库 {overview.failedCount}，建议优先排查
+              Failed: {overview.failedCount}, prioritize investigation
             </p>
           </Card>
           <Card className="p-3">
             <div className="mb-2 flex items-center justify-between text-xs text-muted-foreground">
-              <span>当前页选中占比</span>
+              <span>Page Selection Ratio</span>
               <span>{overview.selectedRate}%</span>
             </div>
             <Progress value={overview.selectedRate} className="h-2.5" />
             <p className="mt-2 text-xs text-muted-foreground">
-              已选择 {selectedIds.size} 项用于批量操作
+              {selectedIds.size} selected for batch operations
             </p>
           </Card>
         </div>
@@ -357,8 +357,8 @@ export default function AdminRepositoriesPage() {
       <Card className="p-4 transition-all duration-300 hover:shadow-sm">
         <div className="space-y-3">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <p className="text-sm font-semibold">当前页状态分布</p>
-            <Badge variant="outline">共 {overview.pageCount} 条</Badge>
+            <p className="text-sm font-semibold">Page Status Distribution</p>
+            <Badge variant="outline">{overview.pageCount} total</Badge>
           </div>
           <div className="h-2.5 w-full overflow-hidden rounded-full bg-muted">
             <div className="flex h-full w-full">
@@ -476,7 +476,7 @@ export default function AdminRepositoriesPage() {
                               type="button"
                               className="font-medium text-left transition-all duration-200 hover:text-primary hover:underline underline-offset-4"
                               onClick={() => router.push(`/${repo.id}`)}
-                              title="管理仓库"
+                              title="Manage repository"
                             >
                               {repo.orgName}/{repo.repoName}
                             </button>
@@ -594,7 +594,7 @@ export default function AdminRepositoriesPage() {
                   ) : (
                     <tr>
                       <td colSpan={7} className="px-4 py-16 text-center text-sm text-muted-foreground animate-in fade-in-0 duration-200">
-                        当前筛选条件下暂无仓库数据
+                        No repositories found for current filters
                       </td>
                     </tr>
                   )}


### PR DESCRIPTION
## Problem

The admin repositories page (`web/app/admin/repositories/page.tsx`) has several hardcoded Chinese strings that are not part of the i18n system, causing them to display in Chinese regardless of locale settings.

## Changes

Translated all hardcoded Chinese strings to English:

| Chinese | English |
|---------|---------|
| 当前页完成率 | Page Completion Rate |
| 完成 X / Y，处理中 Z | Completed X / Y, Processing Z |
| 公开仓库占比 | Public Repository Ratio |
| 失败仓库 X，建议优先排查 | Failed: X, prioritize investigation |
| 当前页选中占比 | Page Selection Ratio |
| 已选择 X 项用于批量操作 | X selected for batch operations |
| 当前页状态分布 | Page Status Distribution |
| 共 X 条 | X total |
| 管理仓库 | Manage repository |
| 当前筛选条件下暂无仓库数据 | No repositories found for current filters |