### PR TITLE
Add MCP server with OAuth 2.1 authentication

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,8 +42,7 @@
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="9.9.0-preview.1.25458.4" />
     <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.65.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Core" Version="1.65.0" />
-    <PackageVersion Include="ModelContextProtocol.Core" Version="0.6.0-preview.1" />
-    <PackageVersion Include="ModelContextProtocolServer.Sse" Version="0.6.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="0.8.0-preview.1" />
     <PackageVersion Include="MySql.EntityFrameworkCore" Version="10.0.0-rc" />
     <PackageVersion Include="OpenAI" Version="2.8.0" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.12.36" />
@@ -101,7 +100,7 @@
     <PackageVersion Include="FastService" Version="0.2.2" />
     <PackageVersion Include="FastService.Analyzers" Version="0.2.2" />
     <!-- 协议支持 -->
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.6.0-preview.1" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.8.0-preview.1" />
     <PackageVersion Include="SharpToken" Version="2.0.4" />
     <!-- Thor 框架相关包 (来自子模块) -->
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/src/OpenDeepWiki/MCP/McpAuthConfiguration.cs
+++ b/src/OpenDeepWiki/MCP/McpAuthConfiguration.cs
@@ -1,0 +1,102 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+
+namespace OpenDeepWiki.MCP;
+
+/// <summary>
+/// Configures MCP server authentication using Google as the OAuth 2.1 authorization server.
+/// Implements Protected Resource Metadata (RFC 9728) for MCP client discovery.
+/// </summary>
+public static class McpAuthConfiguration
+{
+    public const string McpGoogleScheme = "McpGoogle";
+    public const string McpPolicyName = "McpAccess";
+
+    /// <summary>
+    /// Adds Google OAuth token validation as a secondary authentication scheme for MCP.
+    /// </summary>
+    public static AuthenticationBuilder AddMcpGoogleAuth(
+        this AuthenticationBuilder builder,
+        IConfiguration configuration)
+    {
+        var googleClientId = configuration["GOOGLE_CLIENT_ID"]
+                             ?? configuration["Google:ClientId"]
+                             ?? throw new InvalidOperationException(
+                                 "GOOGLE_CLIENT_ID is required for MCP OAuth authentication");
+
+        builder.AddJwtBearer(McpGoogleScheme, options =>
+        {
+            options.Authority = "https://accounts.google.com";
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidIssuers = new[]
+                {
+                    "https://accounts.google.com",
+                    "accounts.google.com"
+                },
+                ValidateAudience = true,
+                ValidAudience = googleClientId,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                NameClaimType = "name",
+                RoleClaimType = "roles"
+            };
+
+            options.Events = new JwtBearerEvents
+            {
+                OnAuthenticationFailed = context =>
+                {
+                    var logger = context.HttpContext.RequestServices
+                        .GetRequiredService<ILoggerFactory>()
+                        .CreateLogger("OpenDeepWiki.MCP.McpAuthConfiguration");
+                    logger.LogDebug("MCP Google auth failed: {Error}", context.Exception.Message);
+                    return Task.CompletedTask;
+                }
+            };
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Maps the Protected Resource Metadata endpoint (RFC 9728).
+    /// Claude and other MCP clients fetch this to discover the authorization server.
+    /// Mapped at both /.well-known/ (standard) and /api/.well-known/ (for reverse proxy setups).
+    /// </summary>
+    public static WebApplication MapProtectedResourceMetadata(
+        this WebApplication app)
+    {
+        app.MapGet("/.well-known/oauth-protected-resource", HandleProtectedResourceMetadata)
+            .AllowAnonymous();
+        app.MapGet("/api/.well-known/oauth-protected-resource", HandleProtectedResourceMetadata)
+            .AllowAnonymous();
+
+        return app;
+    }
+
+    private static IResult HandleProtectedResourceMetadata(HttpContext context)
+    {
+        var config = context.RequestServices.GetRequiredService<IConfiguration>();
+        // Derive public base URL from CORS origins or forwarded headers
+        var baseUrl = config["ASPNETCORE_CORS_ORIGINS"]?.TrimEnd('/');
+        if (string.IsNullOrEmpty(baseUrl))
+        {
+            var request = context.Request;
+            var scheme = request.Headers["X-Forwarded-Proto"].FirstOrDefault() ?? request.Scheme;
+            var host = request.Headers["X-Forwarded-Host"].FirstOrDefault() ?? request.Host.ToString();
+            baseUrl = $"{scheme}://{host}";
+        }
+
+        var metadata = new
+        {
+            resource = $"{baseUrl}/api/mcp",
+            authorization_servers = new[] { baseUrl },
+            scopes_supported = new[] { "openid", "email", "profile" },
+            resource_documentation = $"{baseUrl}/docs/mcp"
+        };
+
+        return Results.Json(metadata);
+    }
+}

--- a/src/OpenDeepWiki/MCP/McpOAuthServer.cs
+++ b/src/OpenDeepWiki/MCP/McpOAuthServer.cs
@@ -1,0 +1,572 @@
+using System.Collections.Concurrent;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using OpenDeepWiki.EFCore;
+using OpenDeepWiki.Entities;
+using OpenDeepWiki.Services.Auth;
+
+namespace OpenDeepWiki.MCP;
+
+/// <summary>
+/// OAuth 2.1 Authorization Server that wraps Google OAuth for MCP client authentication.
+/// Claude.ai and other MCP clients expect the MCP server to act as its own OAuth AS.
+/// This implementation proxies the OAuth flow through Google and issues internal JWTs.
+/// </summary>
+public class McpOAuthServer
+{
+    private readonly IConfiguration _configuration;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<McpOAuthServer> _logger;
+    private readonly string _googleClientId;
+    private readonly string _googleClientSecret;
+
+    // In-memory stores for OAuth state (short-lived, lost on restart = clients re-auth)
+    private static readonly ConcurrentDictionary<string, PendingAuthorization> PendingAuthorizations = new();
+    private static readonly ConcurrentDictionary<string, AuthorizationCode> AuthorizationCodes = new();
+
+    // Allowed redirect URIs for MCP clients
+    private static readonly HashSet<string> AllowedRedirectUris = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "https://claude.ai/api/mcp/auth_callback",
+        "https://claude.com/api/mcp/auth_callback",
+        "https://www.claude.ai/api/mcp/auth_callback",
+    };
+
+    public McpOAuthServer(
+        IConfiguration configuration,
+        IHttpClientFactory httpClientFactory,
+        IServiceScopeFactory scopeFactory,
+        ILogger<McpOAuthServer> logger)
+    {
+        _configuration = configuration;
+        _httpClientFactory = httpClientFactory;
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+
+        _googleClientId = configuration["GOOGLE_CLIENT_ID"]
+                          ?? configuration["Google:ClientId"]
+                          ?? throw new InvalidOperationException(
+                              "GOOGLE_CLIENT_ID is required for MCP OAuth");
+
+        _googleClientSecret = configuration["GOOGLE_CLIENT_SECRET"]
+                              ?? configuration["Google:ClientSecret"]
+                              ?? throw new InvalidOperationException(
+                                  "GOOGLE_CLIENT_SECRET is required for MCP OAuth authorization server");
+    }
+
+    /// <summary>
+    /// Returns OAuth Authorization Server Metadata (RFC 8414).
+    /// </summary>
+    public IResult HandleAuthorizationServerMetadata(HttpContext context)
+    {
+        var baseUrl = GetBaseUrl(context);
+
+        var metadata = new
+        {
+            issuer = baseUrl,
+            authorization_endpoint = $"{baseUrl}/oauth/authorize",
+            token_endpoint = $"{baseUrl}/oauth/token",
+            response_types_supported = new[] { "code" },
+            grant_types_supported = new[] { "authorization_code" },
+            code_challenge_methods_supported = new[] { "S256" },
+            scopes_supported = new[] { "openid", "email", "profile" },
+            token_endpoint_auth_methods_supported = new[] { "none" },
+        };
+
+        return Results.Json(metadata);
+    }
+
+    /// <summary>
+    /// Handles the /oauth/authorize request from MCP clients.
+    /// Stores the pending authorization and redirects to Google OAuth.
+    /// </summary>
+    public IResult HandleAuthorize(HttpContext context)
+    {
+        var query = context.Request.Query;
+
+        var clientId = query["client_id"].FirstOrDefault();
+        var redirectUri = query["redirect_uri"].FirstOrDefault();
+        var codeChallenge = query["code_challenge"].FirstOrDefault();
+        var codeChallengeMethod = query["code_challenge_method"].FirstOrDefault();
+        var state = query["state"].FirstOrDefault();
+        var scope = query["scope"].FirstOrDefault();
+
+        // Validate required parameters
+        if (string.IsNullOrEmpty(redirectUri))
+        {
+            _logger.LogWarning("MCP OAuth authorize: missing redirect_uri");
+            return Results.BadRequest(new { error = "invalid_request", error_description = "redirect_uri is required" });
+        }
+
+        if (!AllowedRedirectUris.Contains(redirectUri))
+        {
+            _logger.LogWarning("MCP OAuth authorize: disallowed redirect_uri: {RedirectUri}", redirectUri);
+            return Results.BadRequest(new { error = "invalid_request", error_description = "redirect_uri not allowed" });
+        }
+
+        if (string.IsNullOrEmpty(codeChallenge) || codeChallengeMethod != "S256")
+        {
+            _logger.LogWarning("MCP OAuth authorize: missing or invalid PKCE parameters");
+            return Results.BadRequest(new { error = "invalid_request", error_description = "PKCE with S256 is required" });
+        }
+
+        // Generate internal state to map our Google callback back to this request
+        var internalState = GenerateRandomString(32);
+        var baseUrl = GetBaseUrl(context);
+
+        var pending = new PendingAuthorization
+        {
+            ClientId = clientId ?? string.Empty,
+            RedirectUri = redirectUri,
+            CodeChallenge = codeChallenge,
+            State = state ?? string.Empty,
+            Scope = scope ?? string.Empty,
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(10),
+        };
+
+        PendingAuthorizations[internalState] = pending;
+
+        _logger.LogInformation("MCP OAuth authorize: redirecting to Google OAuth (client_id: {ClientId})", clientId);
+
+        // Redirect to Google OAuth
+        var googleAuthUrl = "https://accounts.google.com/o/oauth2/v2/auth"
+                            + $"?client_id={Uri.EscapeDataString(_googleClientId)}"
+                            + $"&redirect_uri={Uri.EscapeDataString($"{baseUrl}/oauth/callback")}"
+                            + "&response_type=code"
+                            + "&scope=openid%20email%20profile"
+                            + $"&state={Uri.EscapeDataString(internalState)}"
+                            + "&access_type=offline"
+                            + "&prompt=consent";
+
+        return Results.Redirect(googleAuthUrl);
+    }
+
+    /// <summary>
+    /// Handles the Google OAuth callback.
+    /// Exchanges the Google code for tokens, resolves the user, and redirects back to the MCP client.
+    /// </summary>
+    public async Task<IResult> HandleCallback(HttpContext context)
+    {
+        var query = context.Request.Query;
+        var googleCode = query["code"].FirstOrDefault();
+        var internalState = query["state"].FirstOrDefault();
+        var error = query["error"].FirstOrDefault();
+
+        if (!string.IsNullOrEmpty(error))
+        {
+            _logger.LogWarning("MCP OAuth callback: Google returned error: {Error}", error);
+            return Results.BadRequest(new { error = "access_denied", error_description = $"Google OAuth error: {error}" });
+        }
+
+        if (string.IsNullOrEmpty(googleCode) || string.IsNullOrEmpty(internalState))
+        {
+            _logger.LogWarning("MCP OAuth callback: missing code or state");
+            return Results.BadRequest(new { error = "invalid_request", error_description = "Missing code or state" });
+        }
+
+        // Look up the pending authorization
+        if (!PendingAuthorizations.TryRemove(internalState, out var pending))
+        {
+            _logger.LogWarning("MCP OAuth callback: unknown or expired state");
+            return Results.BadRequest(new { error = "invalid_request", error_description = "Unknown or expired state" });
+        }
+
+        if (pending.ExpiresAt < DateTime.UtcNow)
+        {
+            _logger.LogWarning("MCP OAuth callback: expired authorization request");
+            return Results.BadRequest(new { error = "invalid_request", error_description = "Authorization request expired" });
+        }
+
+        var baseUrl = GetBaseUrl(context);
+
+        // Exchange Google code for tokens
+        var client = _httpClientFactory.CreateClient();
+        var tokenRequest = new Dictionary<string, string>
+        {
+            ["code"] = googleCode,
+            ["client_id"] = _googleClientId,
+            ["client_secret"] = _googleClientSecret,
+            ["redirect_uri"] = $"{baseUrl}/oauth/callback",
+            ["grant_type"] = "authorization_code",
+        };
+
+        var tokenResponse = await client.PostAsync(
+            "https://oauth2.googleapis.com/token",
+            new FormUrlEncodedContent(tokenRequest));
+
+        if (!tokenResponse.IsSuccessStatusCode)
+        {
+            var errorBody = await tokenResponse.Content.ReadAsStringAsync();
+            _logger.LogError("MCP OAuth callback: Google token exchange failed: {Status} {Body}",
+                tokenResponse.StatusCode, errorBody);
+            return Results.BadRequest(new { error = "server_error", error_description = "Failed to exchange code with Google" });
+        }
+
+        var tokenJson = await tokenResponse.Content.ReadAsStringAsync();
+        var tokenData = JsonSerializer.Deserialize<JsonElement>(tokenJson);
+
+        // Extract user info from the ID token
+        var idToken = tokenData.GetProperty("id_token").GetString();
+        if (string.IsNullOrEmpty(idToken))
+        {
+            _logger.LogError("MCP OAuth callback: no id_token in Google response");
+            return Results.BadRequest(new { error = "server_error", error_description = "No ID token from Google" });
+        }
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(idToken);
+        var email = jwt.Claims.FirstOrDefault(c => c.Type == "email")?.Value;
+        var name = jwt.Claims.FirstOrDefault(c => c.Type == "name")?.Value ?? email;
+
+        if (string.IsNullOrEmpty(email))
+        {
+            _logger.LogError("MCP OAuth callback: no email in Google ID token");
+            return Results.BadRequest(new { error = "server_error", error_description = "No email in Google token" });
+        }
+
+        // Look up or create user in database
+        string userId;
+        using (var scope = _scopeFactory.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<IContext>();
+
+            var user = await dbContext.Users
+                .FirstOrDefaultAsync(u => u.Email == email && !u.IsDeleted);
+
+            if (user == null)
+            {
+                // Create new user
+                user = new User
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Name = name ?? email,
+                    Email = email,
+                    Status = 1,
+                    CreatedAt = DateTime.UtcNow,
+                };
+                dbContext.Users.Add(user);
+
+                // Assign default role
+                var defaultRole = await dbContext.Roles
+                    .FirstOrDefaultAsync(r => r.Name == "User" && !r.IsDeleted);
+
+                if (defaultRole != null)
+                {
+                    dbContext.UserRoles.Add(new UserRole
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        UserId = user.Id,
+                        RoleId = defaultRole.Id,
+                        CreatedAt = DateTime.UtcNow,
+                    });
+                }
+
+                _logger.LogInformation("MCP OAuth: created new user {Email}", email);
+            }
+
+            user.LastLoginAt = DateTime.UtcNow;
+            user.UpdateTimestamp();
+            await dbContext.SaveChangesAsync();
+            userId = user.Id;
+        }
+
+        // Generate our authorization code
+        var authCode = GenerateRandomString(48);
+        AuthorizationCodes[authCode] = new AuthorizationCode
+        {
+            Code = authCode,
+            UserId = userId,
+            Email = email,
+            Name = name ?? email,
+            ClientId = pending.ClientId,
+            RedirectUri = pending.RedirectUri,
+            CodeChallenge = pending.CodeChallenge,
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(5),
+        };
+
+        _logger.LogInformation("MCP OAuth callback: issuing auth code for {Email}, redirecting to {RedirectUri}", email, pending.RedirectUri);
+
+        // Redirect back to the MCP client with our authorization code
+        var redirectUrl = $"{pending.RedirectUri}?code={Uri.EscapeDataString(authCode)}";
+        if (!string.IsNullOrEmpty(pending.State))
+        {
+            redirectUrl += $"&state={Uri.EscapeDataString(pending.State)}";
+        }
+
+        // Return HTML page that redirects and then closes the tab
+        var safeUrl = System.Text.Json.JsonSerializer.Serialize(redirectUrl);
+        var html = "<!DOCTYPE html><html><head><title>Authorizing...</title></head><body>"
+                   + "<p>Authentication successful. Redirecting...</p>"
+                   + "<script>window.location.href=" + safeUrl + ";"
+                   + "setTimeout(function(){window.close();},2000);</script>"
+                   + "</body></html>";
+        return Results.Content(html, "text/html");
+    }
+
+    /// <summary>
+    /// Handles the POST /oauth/token request from MCP clients.
+    /// Validates PKCE and exchanges our authorization code for a JWT.
+    /// </summary>
+    public async Task<IResult> HandleToken(HttpContext context)
+    {
+        // Read form data
+        var form = await context.Request.ReadFormAsync();
+        var grantType = form["grant_type"].FirstOrDefault();
+        var code = form["code"].FirstOrDefault();
+        var codeVerifier = form["code_verifier"].FirstOrDefault();
+        var clientId = form["client_id"].FirstOrDefault();
+        var redirectUri = form["redirect_uri"].FirstOrDefault();
+
+        if (grantType != "authorization_code")
+        {
+            return Results.Json(
+                new { error = "unsupported_grant_type", error_description = "Only authorization_code is supported" },
+                statusCode: 400);
+        }
+
+        if (string.IsNullOrEmpty(code))
+        {
+            return Results.Json(
+                new { error = "invalid_request", error_description = "code is required" },
+                statusCode: 400);
+        }
+
+        // Look up and consume the authorization code (single-use)
+        if (!AuthorizationCodes.TryRemove(code, out var authCode))
+        {
+            _logger.LogWarning("MCP OAuth token: unknown or already-used code");
+            return Results.Json(
+                new { error = "invalid_grant", error_description = "Invalid or expired authorization code" },
+                statusCode: 400);
+        }
+
+        if (authCode.ExpiresAt < DateTime.UtcNow)
+        {
+            _logger.LogWarning("MCP OAuth token: expired authorization code");
+            return Results.Json(
+                new { error = "invalid_grant", error_description = "Authorization code expired" },
+                statusCode: 400);
+        }
+
+        // Validate client_id and redirect_uri match
+        if (!string.IsNullOrEmpty(clientId) && clientId != authCode.ClientId)
+        {
+            _logger.LogWarning("MCP OAuth token: client_id mismatch");
+            return Results.Json(
+                new { error = "invalid_grant", error_description = "client_id mismatch" },
+                statusCode: 400);
+        }
+
+        if (!string.IsNullOrEmpty(redirectUri) && redirectUri != authCode.RedirectUri)
+        {
+            _logger.LogWarning("MCP OAuth token: redirect_uri mismatch");
+            return Results.Json(
+                new { error = "invalid_grant", error_description = "redirect_uri mismatch" },
+                statusCode: 400);
+        }
+
+        // Validate PKCE
+        if (!string.IsNullOrEmpty(authCode.CodeChallenge))
+        {
+            if (string.IsNullOrEmpty(codeVerifier))
+            {
+                _logger.LogWarning("MCP OAuth token: missing code_verifier");
+                return Results.Json(
+                    new { error = "invalid_grant", error_description = "code_verifier is required" },
+                    statusCode: 400);
+            }
+
+            var expectedChallenge = ComputeS256Challenge(codeVerifier);
+            if (expectedChallenge != authCode.CodeChallenge)
+            {
+                _logger.LogWarning("MCP OAuth token: PKCE verification failed");
+                return Results.Json(
+                    new { error = "invalid_grant", error_description = "PKCE verification failed" },
+                    statusCode: 400);
+            }
+        }
+
+        // Generate JWT using existing JwtService
+        string accessToken;
+        using (var scope = _scopeFactory.CreateScope())
+        {
+            var jwtService = scope.ServiceProvider.GetRequiredService<IJwtService>();
+            var dbContext = scope.ServiceProvider.GetRequiredService<IContext>();
+
+            var user = await dbContext.Users.FirstOrDefaultAsync(u => u.Id == authCode.UserId && !u.IsDeleted);
+            if (user == null)
+            {
+                return Results.Json(
+                    new { error = "invalid_grant", error_description = "User not found" },
+                    statusCode: 400);
+            }
+
+            var roles = await dbContext.UserRoles
+                .Where(ur => ur.UserId == user.Id && !ur.IsDeleted)
+                .Join(dbContext.Roles, ur => ur.RoleId, r => r.Id, (_, r) => r.Name)
+                .ToListAsync();
+
+            accessToken = jwtService.GenerateToken(user, roles);
+        }
+
+        _logger.LogInformation("MCP OAuth token: issued JWT for {Email}", authCode.Email);
+
+        return Results.Json(new
+        {
+            access_token = accessToken,
+            token_type = "Bearer",
+            expires_in = 86400, // 24 hours (matches JwtOptions default)
+        });
+    }
+
+    /// <summary>
+    /// Removes expired entries from the in-memory stores.
+    /// </summary>
+    public static void CleanupExpiredEntries()
+    {
+        var now = DateTime.UtcNow;
+
+        foreach (var kvp in PendingAuthorizations)
+        {
+            if (kvp.Value.ExpiresAt < now)
+                PendingAuthorizations.TryRemove(kvp.Key, out _);
+        }
+
+        foreach (var kvp in AuthorizationCodes)
+        {
+            if (kvp.Value.ExpiresAt < now)
+                AuthorizationCodes.TryRemove(kvp.Key, out _);
+        }
+    }
+
+    private string GetBaseUrl(HttpContext context)
+    {
+        var baseUrl = _configuration["ASPNETCORE_CORS_ORIGINS"]?.TrimEnd('/');
+        if (string.IsNullOrEmpty(baseUrl))
+        {
+            var request = context.Request;
+            var scheme = request.Headers["X-Forwarded-Proto"].FirstOrDefault() ?? request.Scheme;
+            var host = request.Headers["X-Forwarded-Host"].FirstOrDefault() ?? request.Host.ToString();
+            baseUrl = $"{scheme}://{host}";
+        }
+
+        return baseUrl;
+    }
+
+    private static string GenerateRandomString(int length)
+    {
+        var bytes = new byte[length];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(bytes);
+        return Convert.ToBase64String(bytes)
+            .Replace("+", "-")
+            .Replace("/", "_")
+            .TrimEnd('=')[..length];
+    }
+
+    private static string ComputeS256Challenge(string codeVerifier)
+    {
+        var bytes = SHA256.HashData(Encoding.ASCII.GetBytes(codeVerifier));
+        return Convert.ToBase64String(bytes)
+            .Replace("+", "-")
+            .Replace("/", "_")
+            .TrimEnd('=');
+    }
+}
+
+/// <summary>
+/// Extension methods to map MCP OAuth endpoints in Program.cs.
+/// </summary>
+public static class McpOAuthEndpoints
+{
+    public static WebApplication MapMcpOAuthEndpoints(this WebApplication app)
+    {
+        var oauthServer = app.Services.GetRequiredService<McpOAuthServer>();
+
+        // Authorization server metadata (RFC 8414)
+        app.MapGet("/.well-known/oauth-authorization-server",
+                oauthServer.HandleAuthorizationServerMetadata)
+            .AllowAnonymous();
+        app.MapGet("/api/.well-known/oauth-authorization-server",
+                oauthServer.HandleAuthorizationServerMetadata)
+            .AllowAnonymous();
+
+        // OAuth endpoints (proxied from frontend via /oauth/* catch-all route)
+        // NOTE: Handlers returning async Task<IResult> with HttpContext parameter are
+        // ambiguous with RequestDelegate (HttpContext -> Task) due to covariance.
+        // We must explicitly execute the IResult to avoid ASP.NET ignoring the return value.
+        app.MapGet("/oauth/authorize", oauthServer.HandleAuthorize)
+            .AllowAnonymous();
+        app.MapGet("/oauth/callback", async (HttpContext ctx) =>
+            {
+                var result = await oauthServer.HandleCallback(ctx);
+                await result.ExecuteAsync(ctx);
+            })
+            .AllowAnonymous();
+        app.MapPost("/oauth/token", async (HttpContext ctx) =>
+            {
+                var result = await oauthServer.HandleToken(ctx);
+                await result.ExecuteAsync(ctx);
+            })
+            .AllowAnonymous();
+
+        return app;
+    }
+}
+
+/// <summary>
+/// Background service that periodically cleans up expired OAuth state.
+/// </summary>
+public class McpOAuthCleanupService : BackgroundService
+{
+    private readonly ILogger<McpOAuthCleanupService> _logger;
+    private static readonly TimeSpan CleanupInterval = TimeSpan.FromMinutes(1);
+
+    public McpOAuthCleanupService(ILogger<McpOAuthCleanupService> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(CleanupInterval, stoppingToken);
+            McpOAuthServer.CleanupExpiredEntries();
+            _logger.LogDebug("MCP OAuth: cleaned up expired entries");
+        }
+    }
+}
+
+// Data structures for in-memory OAuth state
+
+internal class PendingAuthorization
+{
+    public required string ClientId { get; init; }
+    public required string RedirectUri { get; init; }
+    public required string CodeChallenge { get; init; }
+    public required string State { get; init; }
+    public required string Scope { get; init; }
+    public required DateTime CreatedAt { get; init; }
+    public required DateTime ExpiresAt { get; init; }
+}
+
+internal class AuthorizationCode
+{
+    public required string Code { get; init; }
+    public required string UserId { get; init; }
+    public required string Email { get; init; }
+    public required string Name { get; init; }
+    public required string ClientId { get; init; }
+    public required string RedirectUri { get; init; }
+    public required string CodeChallenge { get; init; }
+    public required DateTime CreatedAt { get; init; }
+    public required DateTime ExpiresAt { get; init; }
+}

--- a/src/OpenDeepWiki/MCP/McpRepositoryTools.cs
+++ b/src/OpenDeepWiki/MCP/McpRepositoryTools.cs
@@ -1,0 +1,291 @@
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using ModelContextProtocol.Server;
+using OpenDeepWiki.EFCore;
+
+namespace OpenDeepWiki.MCP;
+
+/// <summary>
+/// MCP tools that expose repository documentation to AI clients (Claude, Cursor, etc.).
+/// All tools verify user access through department assignments before returning data.
+/// </summary>
+[McpServerToolType]
+public class McpRepositoryTools
+{
+    [McpServerTool, Description("List all repositories you have access to. Returns repository names, owners, and status.")]
+    public static async Task<string> ListRepositories(
+        IHttpContextAccessor httpContextAccessor,
+        IMcpUserResolver userResolver)
+    {
+        var user = await ResolveUserOrThrow(httpContextAccessor, userResolver);
+        var repos = await userResolver.GetAccessibleRepositoriesAsync(user.UserId);
+
+        if (repos.Count == 0)
+            return JsonSerializer.Serialize(new { message = "No repositories available. You may not be assigned to any department." });
+
+        return JsonSerializer.Serialize(new
+        {
+            count = repos.Count,
+            repositories = repos.Select(r => new
+            {
+                owner = r.Owner,
+                name = r.Name,
+                status = r.Status,
+                department = r.Department
+            })
+        });
+    }
+
+    [McpServerTool, Description("Get the document catalog (table of contents) for a repository. Use this to discover available documentation paths before reading documents.")]
+    public static async Task<string> GetDocumentCatalog(
+        IHttpContextAccessor httpContextAccessor,
+        IMcpUserResolver userResolver,
+        IContext context,
+        [Description("Repository owner/organization name")] string owner,
+        [Description("Repository name")] string name,
+        [Description("Language code (default: en)")] string language = "en")
+    {
+        var user = await ResolveUserOrThrow(httpContextAccessor, userResolver);
+
+        if (!await userResolver.CanAccessRepositoryAsync(user.UserId, owner, name))
+            return JsonSerializer.Serialize(new { error = true, message = $"Access denied to {owner}/{name}" });
+
+        var repository = await context.Repositories
+            .FirstOrDefaultAsync(r => r.OrgName == owner && r.RepoName == name && !r.IsDeleted);
+
+        if (repository == null)
+            return JsonSerializer.Serialize(new { error = true, message = $"Repository {owner}/{name} not found" });
+
+        // Get default branch
+        var branch = await context.RepositoryBranches
+            .FirstOrDefaultAsync(b => b.RepositoryId == repository.Id && !b.IsDeleted);
+
+        if (branch == null)
+            return JsonSerializer.Serialize(new { error = true, message = "No branch found for this repository" });
+
+        var branchLanguage = await context.BranchLanguages
+            .FirstOrDefaultAsync(bl => bl.RepositoryBranchId == branch.Id &&
+                                       bl.LanguageCode == language && !bl.IsDeleted);
+
+        if (branchLanguage == null)
+            return JsonSerializer.Serialize(new { error = true, message = $"No documentation in language '{language}'" });
+
+        var catalogs = await context.DocCatalogs
+            .Where(c => c.BranchLanguageId == branchLanguage.Id &&
+                        !c.IsDeleted && !string.IsNullOrEmpty(c.DocFileId))
+            .OrderBy(c => c.Order)
+            .Select(c => new { c.Title, c.Path, c.Order, c.ParentId })
+            .ToListAsync();
+
+        if (catalogs.Count == 0)
+            return JsonSerializer.Serialize(new { error = true, message = "No documents available for this repository" });
+
+        return JsonSerializer.Serialize(new
+        {
+            repository = $"{owner}/{name}",
+            branch = branch.BranchName,
+            language,
+            documentCount = catalogs.Count,
+            documents = catalogs.Select(c => new
+            {
+                title = c.Title,
+                path = c.Path,
+                order = c.Order,
+                hasParent = c.ParentId != null
+            })
+        });
+    }
+
+    [McpServerTool, Description("Read a specific document from repository documentation. Use GetDocumentCatalog first to find available paths.")]
+    public static async Task<string> ReadDocument(
+        IHttpContextAccessor httpContextAccessor,
+        IMcpUserResolver userResolver,
+        IContext context,
+        [Description("Repository owner/organization name")] string owner,
+        [Description("Repository name")] string name,
+        [Description("Document path from the catalog")] string path,
+        [Description("Starting line number (1-based, inclusive). Default: 1")] int startLine = 1,
+        [Description("Ending line number (1-based, inclusive). Max 200 lines per request. Default: 200")] int endLine = 200,
+        [Description("Language code (default: en)")] string language = "en")
+    {
+        var user = await ResolveUserOrThrow(httpContextAccessor, userResolver);
+
+        if (!await userResolver.CanAccessRepositoryAsync(user.UserId, owner, name))
+            return JsonSerializer.Serialize(new { error = true, message = $"Access denied to {owner}/{name}" });
+
+        if (startLine < 1) startLine = 1;
+        if (endLine < startLine) endLine = startLine;
+        if (endLine - startLine > 200) endLine = startLine + 200;
+
+        var repository = await context.Repositories
+            .FirstOrDefaultAsync(r => r.OrgName == owner && r.RepoName == name && !r.IsDeleted);
+
+        if (repository == null)
+            return JsonSerializer.Serialize(new { error = true, message = $"Repository {owner}/{name} not found" });
+
+        var branch = await context.RepositoryBranches
+            .FirstOrDefaultAsync(b => b.RepositoryId == repository.Id && !b.IsDeleted);
+
+        if (branch == null)
+            return JsonSerializer.Serialize(new { error = true, message = "No branch found" });
+
+        var branchLanguage = await context.BranchLanguages
+            .FirstOrDefaultAsync(bl => bl.RepositoryBranchId == branch.Id &&
+                                       bl.LanguageCode == language && !bl.IsDeleted);
+
+        if (branchLanguage == null)
+            return JsonSerializer.Serialize(new { error = true, message = $"No documentation in language '{language}'" });
+
+        var catalog = await context.DocCatalogs
+            .FirstOrDefaultAsync(c => c.BranchLanguageId == branchLanguage.Id &&
+                                      c.Path == path && !c.IsDeleted);
+
+        if (catalog == null)
+            return JsonSerializer.Serialize(new { error = true, message = $"Document '{path}' not found" });
+
+        if (string.IsNullOrEmpty(catalog.DocFileId))
+            return JsonSerializer.Serialize(new { error = true, message = $"Document '{path}' has no content" });
+
+        var docFile = await context.DocFiles
+            .FirstOrDefaultAsync(d => d.Id == catalog.DocFileId && !d.IsDeleted);
+
+        if (docFile == null)
+            return JsonSerializer.Serialize(new { error = true, message = $"Document content not found" });
+
+        var allLines = docFile.Content.Split('\n');
+        var totalLines = allLines.Length;
+        var actualEndLine = Math.Min(endLine, totalLines);
+
+        if (startLine > totalLines)
+            return JsonSerializer.Serialize(new { error = true, message = $"startLine ({startLine}) exceeds total lines ({totalLines})" });
+
+        var selectedLines = allLines.Skip(startLine - 1).Take(actualEndLine - startLine + 1);
+        var content = string.Join("\n", selectedLines);
+
+        List<string>? sourceFiles = null;
+        if (!string.IsNullOrEmpty(docFile.SourceFiles))
+        {
+            try { sourceFiles = JsonSerializer.Deserialize<List<string>>(docFile.SourceFiles); }
+            catch { /* ignore parse failure */ }
+        }
+
+        return JsonSerializer.Serialize(new
+        {
+            repository = $"{owner}/{name}",
+            path,
+            title = catalog.Title,
+            content,
+            startLine,
+            endLine = actualEndLine,
+            totalLines,
+            sourceFiles
+        });
+    }
+
+    [McpServerTool, Description("Search across all documents in a repository for content matching a query. Returns matching document paths and snippets.")]
+    public static async Task<string> SearchDocuments(
+        IHttpContextAccessor httpContextAccessor,
+        IMcpUserResolver userResolver,
+        IContext context,
+        [Description("Repository owner/organization name")] string owner,
+        [Description("Repository name")] string name,
+        [Description("Search query (case-insensitive text search)")] string query,
+        [Description("Language code (default: en)")] string language = "en")
+    {
+        var user = await ResolveUserOrThrow(httpContextAccessor, userResolver);
+
+        if (!await userResolver.CanAccessRepositoryAsync(user.UserId, owner, name))
+            return JsonSerializer.Serialize(new { error = true, message = $"Access denied to {owner}/{name}" });
+
+        if (string.IsNullOrWhiteSpace(query))
+            return JsonSerializer.Serialize(new { error = true, message = "Search query is required" });
+
+        var repository = await context.Repositories
+            .FirstOrDefaultAsync(r => r.OrgName == owner && r.RepoName == name && !r.IsDeleted);
+
+        if (repository == null)
+            return JsonSerializer.Serialize(new { error = true, message = $"Repository {owner}/{name} not found" });
+
+        var branch = await context.RepositoryBranches
+            .FirstOrDefaultAsync(b => b.RepositoryId == repository.Id && !b.IsDeleted);
+
+        if (branch == null)
+            return JsonSerializer.Serialize(new { error = true, message = "No branch found" });
+
+        var branchLanguage = await context.BranchLanguages
+            .FirstOrDefaultAsync(bl => bl.RepositoryBranchId == branch.Id &&
+                                       bl.LanguageCode == language && !bl.IsDeleted);
+
+        if (branchLanguage == null)
+            return JsonSerializer.Serialize(new { error = true, message = $"No documentation in language '{language}'" });
+
+        // Search across all doc files for this branch/language
+        var matchingDocs = await context.DocCatalogs
+            .Where(c => c.BranchLanguageId == branchLanguage.Id &&
+                        !c.IsDeleted && !string.IsNullOrEmpty(c.DocFileId))
+            .Join(context.DocFiles.Where(d => !d.IsDeleted),
+                  c => c.DocFileId, d => d.Id,
+                  (c, d) => new { Catalog = c, DocFile = d })
+            .Where(x => x.DocFile.Content.Contains(query, StringComparison.OrdinalIgnoreCase)
+                     || x.Catalog.Title.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .Select(x => new
+            {
+                x.Catalog.Title,
+                x.Catalog.Path,
+                x.DocFile.Content
+            })
+            .Take(10)
+            .ToListAsync();
+
+        var results = matchingDocs.Select(doc =>
+        {
+            // Find first matching line for snippet
+            var lines = doc.Content.Split('\n');
+            var matchLine = -1;
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (lines[i].Contains(query, StringComparison.OrdinalIgnoreCase))
+                {
+                    matchLine = i + 1;
+                    break;
+                }
+            }
+
+            var snippetStart = Math.Max(0, (matchLine > 0 ? matchLine - 1 : 0) - 2);
+            var snippet = string.Join("\n", lines.Skip(snippetStart).Take(5));
+
+            return new
+            {
+                title = doc.Title,
+                path = doc.Path,
+                matchLine,
+                snippet = snippet.Length > 500 ? snippet[..500] + "..." : snippet
+            };
+        });
+
+        return JsonSerializer.Serialize(new
+        {
+            repository = $"{owner}/{name}",
+            query,
+            matchCount = matchingDocs.Count,
+            results
+        });
+    }
+
+    private static async Task<McpUserInfo> ResolveUserOrThrow(
+        IHttpContextAccessor httpContextAccessor, IMcpUserResolver userResolver)
+    {
+        var principal = httpContextAccessor.HttpContext?.User;
+        if (principal == null)
+            throw new UnauthorizedAccessException("No authentication context available");
+
+        var user = await userResolver.ResolveUserAsync(principal);
+        if (user == null)
+            throw new UnauthorizedAccessException("User not found in DeepWiki. Please ensure your Google account is registered.");
+
+        return user;
+    }
+}

--- a/src/OpenDeepWiki/MCP/McpUserResolver.cs
+++ b/src/OpenDeepWiki/MCP/McpUserResolver.cs
@@ -1,0 +1,126 @@
+using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+using OpenDeepWiki.EFCore;
+using OpenDeepWiki.Services.Organizations;
+
+namespace OpenDeepWiki.MCP;
+
+/// <summary>
+/// Resolves authenticated MCP users from Google OAuth or internal JWT tokens
+/// and determines their repository access based on department assignments.
+/// </summary>
+public interface IMcpUserResolver
+{
+    Task<McpUserInfo?> ResolveUserAsync(ClaimsPrincipal principal);
+    Task<List<McpRepositoryInfo>> GetAccessibleRepositoriesAsync(string userId);
+    Task<bool> CanAccessRepositoryAsync(string userId, string owner, string name);
+}
+
+public class McpUserResolver : IMcpUserResolver
+{
+    private readonly IContext _context;
+    private readonly IOrganizationService _orgService;
+
+    public McpUserResolver(IContext context, IOrganizationService orgService)
+    {
+        _context = context;
+        _orgService = orgService;
+    }
+
+    public async Task<McpUserInfo?> ResolveUserAsync(ClaimsPrincipal principal)
+    {
+        // Extract email from claims - works for both Google tokens and internal JWT
+        var email = principal.FindFirstValue(ClaimTypes.Email)
+                    ?? principal.FindFirstValue("email");
+
+        if (string.IsNullOrEmpty(email))
+            return null;
+
+        // Look up user by email
+        var user = await _context.Users
+            .FirstOrDefaultAsync(u => u.Email == email && !u.IsDeleted);
+
+        if (user == null)
+            return null;
+
+        return new McpUserInfo
+        {
+            UserId = user.Id,
+            Email = user.Email,
+            Name = user.Name
+        };
+    }
+
+    public async Task<List<McpRepositoryInfo>> GetAccessibleRepositoriesAsync(string userId)
+    {
+        var results = new List<McpRepositoryInfo>();
+
+        // Get repos via department assignments
+        var deptRepos = await _orgService.GetDepartmentRepositoriesAsync(userId);
+        foreach (var repo in deptRepos)
+        {
+            results.Add(new McpRepositoryInfo
+            {
+                Owner = repo.OrgName,
+                Name = repo.RepoName,
+                GitUrl = repo.GitUrl ?? string.Empty,
+                Status = repo.StatusName ?? string.Empty,
+                Department = repo.DepartmentName ?? string.Empty
+            });
+        }
+
+        // Also include public repos the user owns
+        var ownedPublicRepos = await _context.Repositories
+            .Where(r => r.OwnerUserId == userId && r.IsPublic && !r.IsDeleted)
+            .Select(r => new McpRepositoryInfo
+            {
+                Owner = r.OrgName,
+                Name = r.RepoName,
+                GitUrl = r.GitUrl,
+                Status = r.Status.ToString(),
+                Department = "(owned)"
+            })
+            .ToListAsync();
+
+        foreach (var repo in ownedPublicRepos)
+        {
+            if (!results.Any(r => r.Owner == repo.Owner && r.Name == repo.Name))
+                results.Add(repo);
+        }
+
+        return results;
+    }
+
+    public async Task<bool> CanAccessRepositoryAsync(string userId, string owner, string name)
+    {
+        // Check if repo is public
+        var repo = await _context.Repositories
+            .FirstOrDefaultAsync(r => r.OrgName == owner && r.RepoName == name && !r.IsDeleted);
+
+        if (repo == null)
+            return false;
+
+        if (repo.IsPublic)
+            return true;
+
+        // Check department assignment
+        var deptRepos = await _orgService.GetDepartmentRepositoriesAsync(userId);
+        return deptRepos.Any(r => r.OrgName == owner && r.RepoName == name);
+    }
+}
+
+public class McpUserInfo
+{
+    public required string UserId { get; set; }
+    public required string Email { get; set; }
+    public required string Name { get; set; }
+}
+
+public class McpRepositoryInfo
+{
+    public required string Owner { get; set; }
+    public required string Name { get; set; }
+    public required string GitUrl { get; set; }
+    public required string Status { get; set; }
+    public required string Department { get; set; }
+}

--- a/src/OpenDeepWiki/MCP/SseKeepAliveMiddleware.cs
+++ b/src/OpenDeepWiki/MCP/SseKeepAliveMiddleware.cs
@@ -1,0 +1,168 @@
+using System.IO;
+using System.Threading;
+
+namespace OpenDeepWiki.MCP;
+
+/// <summary>
+/// Middleware that sends periodic keep-alive comments for SSE connections
+/// to prevent MCP client disconnections (Claude Code disconnects after ~5min of inactivity).
+/// </summary>
+public class SseKeepAliveMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly string _path;
+    private static readonly TimeSpan KeepAliveInterval = TimeSpan.FromSeconds(25);
+
+    public SseKeepAliveMiddleware(RequestDelegate next, string path)
+    {
+        _next = next;
+        _path = path;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!context.Request.Path.StartsWithSegments(_path))
+        {
+            await _next(context);
+            return;
+        }
+
+        // Only apply to SSE responses (text/event-stream)
+        var originalBody = context.Response.Body;
+        using var wrappedBody = new SseKeepAliveStream(originalBody, context.RequestAborted);
+        context.Response.Body = wrappedBody;
+
+        try
+        {
+            await _next(context);
+        }
+        finally
+        {
+            context.Response.Body = originalBody;
+        }
+    }
+
+    /// <summary>
+    /// Stream wrapper that sends SSE keep-alive comments periodically.
+    /// </summary>
+    private class SseKeepAliveStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly CancellationToken _ct;
+        private readonly SemaphoreSlim _writeLock = new(1, 1);
+        private readonly Timer _timer;
+        private static readonly byte[] KeepAliveBytes = ": keep-alive\n\n"u8.ToArray();
+
+        public SseKeepAliveStream(Stream inner, CancellationToken ct)
+        {
+            _inner = inner;
+            _ct = ct;
+            _timer = new Timer(SendKeepAlive, null, KeepAliveInterval, KeepAliveInterval);
+        }
+
+        private async void SendKeepAlive(object? state)
+        {
+            if (_ct.IsCancellationRequested) return;
+
+            try
+            {
+                await _writeLock.WaitAsync(_ct);
+                try
+                {
+                    await _inner.WriteAsync(KeepAliveBytes, _ct);
+                    await _inner.FlushAsync(_ct);
+                }
+                finally
+                {
+                    _writeLock.Release();
+                }
+            }
+            catch
+            {
+                // Connection closed, ignore
+            }
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await _writeLock.WaitAsync(cancellationToken);
+            try
+            {
+                await _inner.WriteAsync(buffer.AsMemory(offset, count), cancellationToken);
+            }
+            finally
+            {
+                _writeLock.Release();
+            }
+        }
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await _writeLock.WaitAsync(cancellationToken);
+            try
+            {
+                await _inner.WriteAsync(buffer, cancellationToken);
+            }
+            finally
+            {
+                _writeLock.Release();
+            }
+        }
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            await _writeLock.WaitAsync(cancellationToken);
+            try
+            {
+                await _inner.FlushAsync(cancellationToken);
+            }
+            finally
+            {
+                _writeLock.Release();
+            }
+        }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _writeLock.Wait();
+            try { _inner.Write(buffer, offset, count); }
+            finally { _writeLock.Release(); }
+        }
+        public override void Flush()
+        {
+            _writeLock.Wait();
+            try { _inner.Flush(); }
+            finally { _writeLock.Release(); }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _timer.Dispose();
+                _writeLock.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}
+
+public static class SseKeepAliveExtensions
+{
+    public static IApplicationBuilder UseSseKeepAlive(this IApplicationBuilder app, string path)
+    {
+        return app.UseMiddleware<SseKeepAliveMiddleware>(path);
+    }
+}

--- a/src/OpenDeepWiki/OpenDeepWiki.csproj
+++ b/src/OpenDeepWiki/OpenDeepWiki.csproj
@@ -39,6 +39,7 @@
         <PackageReference Include="Serilog.Enrichers.Process" />
         <PackageReference Include="Serilog.Expressions" />
         <PackageReference Include="YamlDotNet" />
+        <PackageReference Include="ModelContextProtocol.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/web/app/.well-known/[...path]/route.ts
+++ b/web/app/.well-known/[...path]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Proxies /.well-known/* requests to the backend API.
+ * Claude.ai and other MCP clients fetch OAuth metadata from these paths at the origin,
+ * but only /api/* is handled by the main proxy. This route bridges the gap.
+ */
+
+function getApiProxyUrl(): string {
+  if (process.env.API_PROXY_URL) {
+    return process.env.API_PROXY_URL;
+  }
+  return '';
+}
+
+async function proxyRequest(request: NextRequest) {
+  const apiUrl = getApiProxyUrl();
+  if (!apiUrl) {
+    return NextResponse.json(
+      { error: 'API_PROXY_URL_NOT_CONFIGURED' },
+      { status: 503 }
+    );
+  }
+
+  const pathname = request.nextUrl.pathname;
+  const searchParams = request.nextUrl.search;
+  const targetUrl = `${apiUrl}${pathname}${searchParams}`;
+
+  try {
+    const headers = new Headers();
+    request.headers.forEach((value, key) => {
+      if (!['host', 'connection'].includes(key.toLowerCase())) {
+        headers.set(key, value);
+      }
+    });
+
+    const response = await fetch(targetUrl, {
+      method: request.method,
+      headers,
+      body: request.body,
+      // @ts-expect-error duplex is required for streaming body
+      duplex: 'half',
+    });
+
+    const responseHeaders = new Headers();
+    response.headers.forEach((value, key) => {
+      if (!['content-encoding', 'transfer-encoding'].includes(key.toLowerCase())) {
+        responseHeaders.set(key, value);
+      }
+    });
+
+    return new NextResponse(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json(
+      { error: 'PROXY_ERROR', message: errorMessage },
+      { status: 502 }
+    );
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return proxyRequest(request);
+}
+
+export async function POST(request: NextRequest) {
+  return proxyRequest(request);
+}

--- a/web/app/oauth/[...path]/route.ts
+++ b/web/app/oauth/[...path]/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Proxies /oauth/* requests to the backend API.
+ * Claude.ai and other MCP clients hit /oauth/authorize, /oauth/callback, /oauth/token
+ * at the origin during the OAuth flow. This route forwards them to the backend.
+ */
+
+function getApiProxyUrl(): string {
+  if (process.env.API_PROXY_URL) {
+    return process.env.API_PROXY_URL;
+  }
+  return '';
+}
+
+async function proxyRequest(request: NextRequest) {
+  const apiUrl = getApiProxyUrl();
+  if (!apiUrl) {
+    return NextResponse.json(
+      { error: 'API_PROXY_URL_NOT_CONFIGURED' },
+      { status: 503 }
+    );
+  }
+
+  const pathname = request.nextUrl.pathname;
+  const searchParams = request.nextUrl.search;
+  const targetUrl = `${apiUrl}${pathname}${searchParams}`;
+
+  try {
+    const headers = new Headers();
+    request.headers.forEach((value, key) => {
+      if (!['host', 'connection'].includes(key.toLowerCase())) {
+        headers.set(key, value);
+      }
+    });
+
+    const response = await fetch(targetUrl, {
+      method: request.method,
+      headers,
+      body: request.body,
+      // @ts-expect-error duplex is required for streaming body
+      duplex: 'half',
+      // Do NOT follow redirects - /oauth/authorize and /oauth/callback return 302s
+      // that must be passed through to the browser
+      redirect: 'manual',
+    });
+
+    // Pass through redirects directly to the client
+    if (response.status === 302 || response.status === 301) {
+      const location = response.headers.get('location');
+      if (location) {
+        return NextResponse.redirect(location, response.status as 301 | 302);
+      }
+    }
+
+    const responseHeaders = new Headers();
+    response.headers.forEach((value, key) => {
+      if (!['content-encoding', 'transfer-encoding'].includes(key.toLowerCase())) {
+        responseHeaders.set(key, value);
+      }
+    });
+
+    return new NextResponse(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json(
+      { error: 'PROXY_ERROR', message: errorMessage },
+      { status: 502 }
+    );
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return proxyRequest(request);
+}
+
+export async function POST(request: NextRequest) {
+  return proxyRequest(request);
+}


### PR DESCRIPTION
## Summary

Adds a Model Context Protocol (MCP) server that exposes DeepWiki repository documentation to MCP-compatible clients like Claude.ai.

### MCP Tools
- **ListRepositories** - Browse accessible repositories with owner, name, and status
- **GetDocumentCatalog** - Get the table of contents for a repository
- **ReadDocument** - Read documentation content with pagination (max 200 lines per request)
- **SearchDocuments** - Full-text search across repository documentation (top 10 results)

### OAuth 2.1 Authorization Server
- Wraps Google OAuth for MCP client authentication (proxies through Google, issues internal JWTs)
- Implements RFC 8414 (Authorization Server Metadata) at `/.well-known/oauth-authorization-server`
- Implements RFC 9728 (Protected Resource Metadata) at `/.well-known/oauth-protected-resource`
- PKCE (S256) required for all authorization requests
- Allowed redirect URIs: `claude.ai`, `claude.com`, `www.claude.ai`

### Access Control
- Department-based access: users see repositories assigned to their departments
- Public repositories visible to their owners
- User resolution from both Google OAuth tokens and internal JWTs

### Infrastructure
- SSE keep-alive middleware (25s interval) prevents client disconnections during long operations
- Next.js frontend proxy routes for `/.well-known/*` and `/oauth/*` (bridges browser requests to backend)
- MCP server registration is **conditional** on `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` env vars being set - the application starts normally without MCP when these aren't configured
- Auth tab auto-closes after successful authentication

### Configuration

Required environment variables (only when MCP is desired):
- `GOOGLE_CLIENT_ID` - Google OAuth client ID
- `GOOGLE_CLIENT_SECRET` - Google OAuth client secret

MCP endpoint: `/api/mcp` (requires OAuth authentication)

## Files Changed
- `src/OpenDeepWiki/MCP/` - All MCP server code (OAuth, tools, user resolver, SSE middleware)
- `src/OpenDeepWiki/Program.cs` - Service and endpoint registration (conditional)
- `web/app/.well-known/[...path]/route.ts` - Frontend proxy for OAuth metadata
- `web/app/oauth/[...path]/route.ts` - Frontend proxy for OAuth flow
- `Directory.Packages.props` - MCP SDK dependency
- `src/OpenDeepWiki/OpenDeepWiki.csproj` - MCP package reference