### PR TITLE
Add Slack messaging provider

### DIFF
--- a/src/OpenDeepWiki/Agents/Tools/ChatMultiRepoDocTool.cs
+++ b/src/OpenDeepWiki/Agents/Tools/ChatMultiRepoDocTool.cs
@@ -1,0 +1,476 @@
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.AI;
+using OpenDeepWiki.EFCore;
+
+namespace OpenDeepWiki.Agents.Tools;
+
+/// <summary>
+/// AI Tool for reading documentation from any accessible repository.
+/// Supports permission-aware filtering: if a DeepWiki user ID is provided,
+/// shows public repos + private repos assigned via departments.
+/// Otherwise shows only public repos.
+/// </summary>
+public class ChatMultiRepoDocTool
+{
+    private readonly IContextFactory _contextFactory;
+    private readonly string _repositorySummary;
+    private readonly string? _deepWikiUserId;
+
+    public ChatMultiRepoDocTool(IContextFactory contextFactory, string repositorySummary, string? deepWikiUserId = null)
+    {
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+        _repositorySummary = repositorySummary ?? string.Empty;
+        _deepWikiUserId = deepWikiUserId;
+    }
+
+    /// <summary>
+    /// Lists all accessible repositories with their documentation status.
+    /// </summary>
+    [Description("List all repositories you have access to in DeepWiki with their branches and languages.")]
+    public async Task<string> ListRepositoriesAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var context = _contextFactory.CreateContext();
+
+            var accessibleRepoIds = await GetAccessibleRepoIdsAsync(context, cancellationToken);
+
+            var query = context.Repositories
+                .Where(r => !r.IsDeleted &&
+                    (r.Status == Entities.RepositoryStatus.Processing ||
+                     r.Status == Entities.RepositoryStatus.Completed));
+
+            if (accessibleRepoIds != null)
+            {
+                // User is mapped: show public + department-assigned repos
+                query = query.Where(r => r.IsPublic || accessibleRepoIds.Contains(r.Id));
+            }
+            else
+            {
+                // User not mapped: public repos only
+                query = query.Where(r => r.IsPublic);
+            }
+
+            var repos = await query
+                .Select(r => new
+                {
+                    r.Id,
+                    r.OrgName,
+                    r.RepoName,
+                    r.PrimaryLanguage,
+                    r.GitUrl,
+                    r.Status,
+                    r.IsPublic
+                })
+                .ToListAsync(cancellationToken);
+
+            if (repos.Count == 0)
+            {
+                return JsonSerializer.Serialize(new { repositories = Array.Empty<object>(), message = "No accessible repositories are currently indexed." });
+            }
+
+            var result = repos.Select(r => new
+            {
+                owner = r.OrgName,
+                repo = r.RepoName,
+                primaryLanguage = r.PrimaryLanguage,
+                url = r.GitUrl,
+                status = r.Status == Entities.RepositoryStatus.Completed ? "ready" : "indexing",
+                visibility = r.IsPublic ? "public" : "private"
+            });
+
+            return JsonSerializer.Serialize(new { repositories = result, count = repos.Count });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { error = true, message = $"Failed to list repositories: {ex.Message}" });
+        }
+    }
+
+    /// <summary>
+    /// Lists documentation catalog for a specific repository.
+    /// </summary>
+    [Description("List the documentation catalog (table of contents) for a specific repository. Use this to discover available documents before reading them.")]
+    public async Task<string> ListDocumentsAsync(
+        [Description("Repository owner/organization (e.g. 'keboola')")] string owner,
+        [Description("Repository name (e.g. 'go-client')")] string repo,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(repo))
+        {
+            return JsonSerializer.Serialize(new { error = true, message = "Owner and repo are required." });
+        }
+
+        try
+        {
+            using var context = _contextFactory.CreateContext();
+
+            var repository = await context.Repositories
+                .FirstOrDefaultAsync(r => r.OrgName == owner && r.RepoName == repo && !r.IsDeleted, cancellationToken);
+
+            if (repository == null)
+            {
+                return JsonSerializer.Serialize(new { error = true, message = $"Repository '{owner}/{repo}' not found." });
+            }
+
+            // Check access permission
+            if (!await CanAccessRepositoryAsync(context, repository.Id, repository.IsPublic, cancellationToken))
+            {
+                return JsonSerializer.Serialize(new { error = true, message = $"You don't have access to repository '{owner}/{repo}'." });
+            }
+
+            // Get the first available branch
+            var branch = await context.RepositoryBranches
+                .FirstOrDefaultAsync(b => b.RepositoryId == repository.Id && !b.IsDeleted, cancellationToken);
+
+            if (branch == null)
+            {
+                return JsonSerializer.Serialize(new { error = true, message = $"No branches found for '{owner}/{repo}'." });
+            }
+
+            // Prefer English, fall back to first available language
+            var branchLanguage = await context.BranchLanguages
+                .Where(bl => bl.RepositoryBranchId == branch.Id && !bl.IsDeleted)
+                .OrderByDescending(bl => bl.LanguageCode == "en")
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (branchLanguage == null)
+            {
+                return JsonSerializer.Serialize(new { error = true, message = $"No documentation languages found for '{owner}/{repo}'." });
+            }
+
+            var catalogs = await context.DocCatalogs
+                .Where(c => c.BranchLanguageId == branchLanguage.Id && !c.IsDeleted && !string.IsNullOrEmpty(c.DocFileId))
+                .OrderBy(c => c.Order)
+                .Select(c => new { c.Title, c.Path })
+                .ToListAsync(cancellationToken);
+
+            if (catalogs.Count == 0)
+            {
+                return JsonSerializer.Serialize(new { error = true, message = $"No documents found for '{owner}/{repo}'." });
+            }
+
+            return JsonSerializer.Serialize(new
+            {
+                repository = $"{owner}/{repo}",
+                branch = branch.BranchName,
+                language = branchLanguage.LanguageCode,
+                documents = catalogs,
+                count = catalogs.Count
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { error = true, message = $"Failed to list documents: {ex.Message}" });
+        }
+    }
+
+    /// <summary>
+    /// Reads document content from a specific repository.
+    /// </summary>
+    [Description("Read documentation content from a specific repository. Use ListDocuments first to discover available document paths.")]
+    public async Task<string> ReadDocAsync(
+        [Description("Repository owner/organization (e.g. 'keboola')")] string owner,
+        [Description("Repository name (e.g. 'go-client')")] string repo,
+        [Description("Document path from the catalog (e.g. 'overview')")] string path,
+        [Description("Starting line number (1-based, inclusive)")] int startLine,
+        [Description("Ending line number (1-based, inclusive, max 200 lines per request)")] int endLine,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(repo))
+        {
+            return JsonSerializer.Serialize(new { error = true, message = "Owner and repo are required." });
+        }
+
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return JsonSerializer.Serialize(new { error = true, message = "Document path is required." });
+        }
+
+        if (startLine < 1)
+        {
+            return JsonSerializer.Serialize(new { error = true, message = "startLine must be >= 1." });
+        }
+
+        if (endLine < startLine)
+        {
+            return JsonSerializer.Serialize(new { error = true, message = "endLine must be >= startLine." });
+        }
+
+        if (endLine - startLine > 200)
+        {
+            return JsonSerializer.Serialize(new { error = true, message = "Maximum 200 lines per request. Narrow your range." });
+        }
+
+        try
+        {
+            using var context = _contextFactory.CreateContext();
+
+            var repository = await context.Repositories
+                .FirstOrDefaultAsync(r => r.OrgName == owner && r.RepoName == repo && !r.IsDeleted, cancellationToken);
+
+            if (repository == null)
+            {
+                return JsonSerializer.Serialize(new { error = true, message = $"Repository '{owner}/{repo}' not found." });
+            }
+
+            // Check access permission
+            if (!await CanAccessRepositoryAsync(context, repository.Id, repository.IsPublic, cancellationToken))
+            {
+                return JsonSerializer.Serialize(new { error = true, message = $"You don't have access to repository '{owner}/{repo}'." });
+            }
+
+            var branch = await context.RepositoryBranches
+                .FirstOrDefaultAsync(b => b.RepositoryId == repository.Id && !b.IsDeleted, cancellationToken);
+
+            if (branch == null)
+            {
+                return JsonSerializer.Serialize(new { error = true, message = $"No branches found for '{owner}/{repo}'." });
+            }
+
+            // Prefer English, fall back to first available language
+            var branchLanguage = await context.BranchLanguages
+                .Where(bl => bl.RepositoryBranchId == branch.Id && !bl.IsDeleted)
+                .OrderByDescending(bl => bl.LanguageCode == "en")
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (branchLanguage == null)
+            {
+                return JsonSerializer.Serialize(new { error = true, message = $"No documentation found for '{owner}/{repo}'." });
+            }
+
+            var catalog = await context.DocCatalogs
+                .FirstOrDefaultAsync(c => c.BranchLanguageId == branchLanguage.Id && c.Path == path && !c.IsDeleted, cancellationToken);
+
+            if (catalog == null)
+            {
+                return JsonSerializer.Serialize(new { error = true, message = $"Document '{path}' not found in '{owner}/{repo}'." });
+            }
+
+            if (string.IsNullOrEmpty(catalog.DocFileId))
+            {
+                return JsonSerializer.Serialize(new { error = true, message = $"Document '{path}' has no content." });
+            }
+
+            var docFile = await context.DocFiles
+                .FirstOrDefaultAsync(d => d.Id == catalog.DocFileId && !d.IsDeleted, cancellationToken);
+
+            if (docFile == null)
+            {
+                return JsonSerializer.Serialize(new { error = true, message = $"Document content not found for '{path}'." });
+            }
+
+            var allLines = docFile.Content.Split('\n');
+            var totalLines = allLines.Length;
+            var actualEndLine = Math.Min(endLine, totalLines);
+
+            if (startLine > totalLines)
+            {
+                return JsonSerializer.Serialize(new
+                {
+                    error = true,
+                    message = $"startLine ({startLine}) exceeds total lines ({totalLines})."
+                });
+            }
+
+            var selectedLines = allLines.Skip(startLine - 1).Take(actualEndLine - startLine + 1);
+            var content = string.Join("\n", selectedLines);
+
+            List<string>? sourceFiles = null;
+            if (!string.IsNullOrEmpty(docFile.SourceFiles))
+            {
+                try
+                {
+                    sourceFiles = JsonSerializer.Deserialize<List<string>>(docFile.SourceFiles);
+                }
+                catch
+                {
+                    // Ignore parse failures
+                }
+            }
+
+            return JsonSerializer.Serialize(new
+            {
+                content,
+                repository = $"{owner}/{repo}",
+                path,
+                startLine,
+                endLine = actualEndLine,
+                totalLines,
+                sourceFiles
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { error = true, message = $"Failed to read document: {ex.Message}" });
+        }
+    }
+
+    /// <summary>
+    /// Gets all AI tools provided by this class.
+    /// </summary>
+    public IList<AITool> GetTools()
+    {
+        var tools = new List<AITool>();
+
+        tools.Add(AIFunctionFactory.Create(ListRepositoriesAsync, new AIFunctionFactoryOptions
+        {
+            Name = "ListRepositories",
+            Description = BuildListReposDescription()
+        }));
+
+        tools.Add(AIFunctionFactory.Create(ListDocumentsAsync, new AIFunctionFactoryOptions
+        {
+            Name = "ListDocuments",
+            Description = "List the documentation catalog (table of contents) for a specific repository. Use this to discover available document paths before reading them with ReadDoc."
+        }));
+
+        tools.Add(AIFunctionFactory.Create(ReadDocAsync, new AIFunctionFactoryOptions
+        {
+            Name = "ReadDoc",
+            Description = "Read documentation content from a repository. Specify owner, repo, document path, and line range. Use ListDocuments first to find available paths. Maximum 200 lines per request."
+        }));
+
+        return tools;
+    }
+
+    private string BuildListReposDescription()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("List all repositories you have access to in DeepWiki.");
+        if (!string.IsNullOrEmpty(_repositorySummary))
+        {
+            sb.AppendLine();
+            sb.AppendLine("Currently accessible repositories:");
+            sb.AppendLine(_repositorySummary);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Creates a ChatMultiRepoDocTool with a pre-loaded repository summary.
+    /// </summary>
+    public static async Task<ChatMultiRepoDocTool> CreateAsync(
+        IContextFactory contextFactory,
+        string? deepWikiUserId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var summary = await LoadRepositorySummaryAsync(contextFactory, deepWikiUserId, cancellationToken);
+        return new ChatMultiRepoDocTool(contextFactory, summary, deepWikiUserId);
+    }
+
+    private static async Task<string> LoadRepositorySummaryAsync(
+        IContextFactory contextFactory,
+        string? deepWikiUserId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var context = contextFactory.CreateContext();
+
+            HashSet<string>? accessibleRepoIds = null;
+            if (!string.IsNullOrEmpty(deepWikiUserId))
+            {
+                accessibleRepoIds = await GetAccessibleRepoIdsStaticAsync(context, deepWikiUserId, cancellationToken);
+            }
+
+            var query = context.Repositories
+                .Where(r => !r.IsDeleted &&
+                    (r.Status == Entities.RepositoryStatus.Processing ||
+                     r.Status == Entities.RepositoryStatus.Completed));
+
+            if (accessibleRepoIds != null)
+            {
+                query = query.Where(r => r.IsPublic || accessibleRepoIds.Contains(r.Id));
+            }
+            else
+            {
+                query = query.Where(r => r.IsPublic);
+            }
+
+            var repos = await query
+                .Select(r => new { r.OrgName, r.RepoName, r.PrimaryLanguage, r.IsPublic })
+                .ToListAsync(cancellationToken);
+
+            if (repos.Count == 0) return "(No accessible repositories indexed)";
+
+            var sb = new StringBuilder();
+            foreach (var r in repos)
+            {
+                var lang = !string.IsNullOrEmpty(r.PrimaryLanguage) ? $" ({r.PrimaryLanguage})" : "";
+                var vis = r.IsPublic ? "" : " [private]";
+                sb.AppendLine($"- {r.OrgName}/{r.RepoName}{lang}{vis}");
+            }
+            return sb.ToString();
+        }
+        catch
+        {
+            return "(Failed to load repository list)";
+        }
+    }
+
+    /// <summary>
+    /// Gets the set of repository IDs the user can access via department assignments.
+    /// Returns null if no user is mapped (public-only mode).
+    /// </summary>
+    private async Task<HashSet<string>?> GetAccessibleRepoIdsAsync(
+        IContext context,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(_deepWikiUserId))
+            return null;
+
+        return await GetAccessibleRepoIdsStaticAsync(context, _deepWikiUserId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets repo IDs accessible to a user via department assignments.
+    /// </summary>
+    private static async Task<HashSet<string>> GetAccessibleRepoIdsStaticAsync(
+        IContext context,
+        string userId,
+        CancellationToken cancellationToken)
+    {
+        // Get user's department IDs
+        var departmentIds = await context.UserDepartments
+            .Where(ud => ud.UserId == userId && !ud.IsDeleted)
+            .Select(ud => ud.DepartmentId)
+            .ToListAsync(cancellationToken);
+
+        if (departmentIds.Count == 0)
+            return new HashSet<string>();
+
+        // Get repository IDs assigned to those departments
+        var repoIds = await context.RepositoryAssignments
+            .Where(ra => departmentIds.Contains(ra.DepartmentId) && !ra.IsDeleted)
+            .Select(ra => ra.RepositoryId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        return new HashSet<string>(repoIds);
+    }
+
+    /// <summary>
+    /// Checks whether the current user can access a specific repository.
+    /// Public repos are always accessible. Private repos require department assignment.
+    /// </summary>
+    private async Task<bool> CanAccessRepositoryAsync(
+        IContext context,
+        string repositoryId,
+        bool isPublic,
+        CancellationToken cancellationToken)
+    {
+        // Public repos are always accessible
+        if (isPublic) return true;
+
+        // If no user is mapped, deny access to private repos
+        if (string.IsNullOrEmpty(_deepWikiUserId)) return false;
+
+        // Check department assignment
+        var accessibleRepoIds = await GetAccessibleRepoIdsAsync(context, cancellationToken);
+        return accessibleRepoIds?.Contains(repositoryId) ?? false;
+    }
+}

--- a/src/OpenDeepWiki/Chat/Abstractions/ChatMessage.cs
+++ b/src/OpenDeepWiki/Chat/Abstractions/ChatMessage.cs
@@ -12,5 +12,5 @@ public class ChatMessage : IChatMessage
     public ChatMessageType MessageType { get; init; } = ChatMessageType.Text;
     public string Platform { get; init; } = string.Empty;
     public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
-    public IDictionary<string, object>? Metadata { get; init; }
+    public IDictionary<string, object>? Metadata { get; set; }
 }

--- a/src/OpenDeepWiki/Chat/Execution/AgentExecutorOptions.cs
+++ b/src/OpenDeepWiki/Chat/Execution/AgentExecutorOptions.cs
@@ -1,37 +1,37 @@
 namespace OpenDeepWiki.Chat.Execution;
 
 /// <summary>
-/// Agent 执行器配置选项
+/// Agent executor configuration options.
 /// </summary>
 public class AgentExecutorOptions
 {
     /// <summary>
-    /// 默认模型名称
+    /// Default model name.
     /// </summary>
     public string DefaultModel { get; set; } = "gpt-4o-mini";
-    
+
     /// <summary>
-    /// 执行超时时间（秒）
+    /// Execution timeout in seconds.
     /// </summary>
     public int TimeoutSeconds { get; set; } = 120;
-    
+
     /// <summary>
-    /// 最大重试次数
+    /// Maximum retry count.
     /// </summary>
     public int MaxRetries { get; set; } = 3;
-    
+
     /// <summary>
-    /// 默认系统提示
+    /// Default system prompt (used as fallback if DeepWiki prompt fails).
     /// </summary>
     public string DefaultSystemPrompt { get; set; } = "You are a helpful assistant.";
-    
+
     /// <summary>
-    /// 是否启用流式响应
+    /// Whether to enable streaming responses.
     /// </summary>
     public bool EnableStreaming { get; set; } = true;
-    
+
     /// <summary>
-    /// 友好错误消息模板
+    /// Friendly error message shown to users when an error occurs.
     /// </summary>
-    public string FriendlyErrorMessage { get; set; } = "抱歉，处理您的消息时遇到了问题，请稍后重试。";
+    public string FriendlyErrorMessage { get; set; } = "Sorry, an error occurred while processing your message. Please try again later.";
 }

--- a/src/OpenDeepWiki/Chat/Execution/ChatUserResolver.cs
+++ b/src/OpenDeepWiki/Chat/Execution/ChatUserResolver.cs
@@ -1,0 +1,166 @@
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenDeepWiki.Chat.Providers.Slack;
+using OpenDeepWiki.EFCore;
+
+namespace OpenDeepWiki.Chat.Execution;
+
+/// <summary>
+/// Resolves messaging platform user IDs to DeepWiki user IDs via email matching.
+/// </summary>
+public interface IChatUserResolver
+{
+    /// <summary>
+    /// Resolves a platform user ID to a DeepWiki user ID.
+    /// Returns null if the user cannot be mapped.
+    /// </summary>
+    Task<string?> ResolveDeepWikiUserIdAsync(string platformUserId, string platform, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Resolves Slack (and other platform) user IDs to DeepWiki user IDs by email matching.
+/// Singleton service with in-memory caching.
+/// </summary>
+public class ChatUserResolver : IChatUserResolver
+{
+    private readonly IContextFactory _contextFactory;
+    private readonly SlackProviderOptions _slackOptions;
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<ChatUserResolver> _logger;
+
+    // Cache: "platform:userId" -> DeepWiki user ID (or null for unmapped)
+    private readonly ConcurrentDictionary<string, CachedResolution> _cache = new();
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(30);
+
+    public ChatUserResolver(
+        IContextFactory contextFactory,
+        IOptions<SlackProviderOptions> slackOptions,
+        HttpClient httpClient,
+        ILogger<ChatUserResolver> logger)
+    {
+        _contextFactory = contextFactory;
+        _slackOptions = slackOptions.Value;
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task<string?> ResolveDeepWikiUserIdAsync(
+        string platformUserId,
+        string platform,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(platformUserId) || string.IsNullOrWhiteSpace(platform))
+            return null;
+
+        var cacheKey = $"{platform}:{platformUserId}";
+
+        // Check cache (with TTL)
+        if (_cache.TryGetValue(cacheKey, out var cached) && !cached.IsExpired)
+        {
+            _logger.LogDebug("Cache hit for {CacheKey}: {UserId}", cacheKey, cached.DeepWikiUserId ?? "(unmapped)");
+            return cached.DeepWikiUserId;
+        }
+
+        // Resolve based on platform
+        string? deepWikiUserId = null;
+        try
+        {
+            var email = platform.ToLowerInvariant() switch
+            {
+                "slack" => await GetSlackUserEmailAsync(platformUserId, cancellationToken),
+                _ => null
+            };
+
+            if (!string.IsNullOrEmpty(email))
+            {
+                deepWikiUserId = await FindDeepWikiUserByEmailAsync(email, cancellationToken);
+
+                if (deepWikiUserId != null)
+                {
+                    _logger.LogInformation(
+                        "Mapped {Platform} user {PlatformUserId} ({Email}) to DeepWiki user {DeepWikiUserId}",
+                        platform, platformUserId, email, deepWikiUserId);
+                }
+                else
+                {
+                    _logger.LogDebug(
+                        "No DeepWiki account found for {Platform} user {PlatformUserId} ({Email})",
+                        platform, platformUserId, email);
+                }
+            }
+            else
+            {
+                _logger.LogDebug(
+                    "Could not resolve email for {Platform} user {PlatformUserId}",
+                    platform, platformUserId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to resolve {Platform} user {PlatformUserId} to DeepWiki user",
+                platform, platformUserId);
+        }
+
+        // Cache the result (even null = "unmapped")
+        _cache[cacheKey] = new CachedResolution(deepWikiUserId, DateTimeOffset.UtcNow.Add(CacheDuration));
+        return deepWikiUserId;
+    }
+
+    /// <summary>
+    /// Calls Slack users.info API to get the user's email address.
+    /// Requires users:read.email OAuth scope on the Slack App.
+    /// </summary>
+    private async Task<string?> GetSlackUserEmailAsync(string slackUserId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(_slackOptions.BotToken))
+        {
+            _logger.LogWarning("Slack BotToken not configured, cannot resolve user email");
+            return null;
+        }
+
+        var url = $"{_slackOptions.ApiBaseUrl}/users.info?user={slackUserId}";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _slackOptions.BotToken);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        var userInfoResponse = JsonSerializer.Deserialize<SlackUserInfoResponse>(content);
+
+        if (userInfoResponse?.Ok != true)
+        {
+            _logger.LogWarning("Slack users.info failed for {UserId}: {Error}",
+                slackUserId, userInfoResponse?.Error);
+            return null;
+        }
+
+        var email = userInfoResponse.UserInfo?.Profile?.Email;
+        if (string.IsNullOrEmpty(email))
+        {
+            _logger.LogDebug("No email found for Slack user {UserId}. " +
+                "Ensure the Slack App has users:read.email scope.", slackUserId);
+        }
+
+        return email;
+    }
+
+    /// <summary>
+    /// Finds a DeepWiki user by email address.
+    /// </summary>
+    private async Task<string?> FindDeepWikiUserByEmailAsync(string email, CancellationToken cancellationToken)
+    {
+        using var context = _contextFactory.CreateContext();
+        var user = await context.Users
+            .FirstOrDefaultAsync(u => u.Email == email && !u.IsDeleted && u.Status == 1, cancellationToken);
+        return user?.Id;
+    }
+
+    private record CachedResolution(string? DeepWikiUserId, DateTimeOffset ExpiresAt)
+    {
+        public bool IsExpired => DateTimeOffset.UtcNow >= ExpiresAt;
+    }
+}

--- a/src/OpenDeepWiki/Chat/Providers/Slack/SlackModels.cs
+++ b/src/OpenDeepWiki/Chat/Providers/Slack/SlackModels.cs
@@ -1,0 +1,267 @@
+using System.Text.Json.Serialization;
+
+namespace OpenDeepWiki.Chat.Providers.Slack;
+
+#region Events API Models
+
+/// <summary>
+/// Slack Events API envelope.
+/// Handles both url_verification challenges and event_callback payloads.
+/// </summary>
+public class SlackEventEnvelope
+{
+    [JsonPropertyName("token")]
+    public string? Token { get; set; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("challenge")]
+    public string? Challenge { get; set; }
+
+    [JsonPropertyName("team_id")]
+    public string? TeamId { get; set; }
+
+    [JsonPropertyName("api_app_id")]
+    public string? ApiAppId { get; set; }
+
+    [JsonPropertyName("event")]
+    public SlackEvent? Event { get; set; }
+
+    [JsonPropertyName("event_id")]
+    public string? EventId { get; set; }
+
+    [JsonPropertyName("event_time")]
+    public long EventTime { get; set; }
+}
+
+/// <summary>
+/// Slack event payload within the envelope
+/// </summary>
+public class SlackEvent
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("subtype")]
+    public string? Subtype { get; set; }
+
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
+
+    [JsonPropertyName("bot_id")]
+    public string? BotId { get; set; }
+
+    [JsonPropertyName("text")]
+    public string? Text { get; set; }
+
+    [JsonPropertyName("ts")]
+    public string? Ts { get; set; }
+
+    [JsonPropertyName("channel")]
+    public string? Channel { get; set; }
+
+    [JsonPropertyName("channel_type")]
+    public string? ChannelType { get; set; }
+
+    [JsonPropertyName("thread_ts")]
+    public string? ThreadTs { get; set; }
+
+    [JsonPropertyName("files")]
+    public List<SlackFile>? Files { get; set; }
+}
+
+/// <summary>
+/// Slack file attachment within a message event
+/// </summary>
+public class SlackFile
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("mimetype")]
+    public string? Mimetype { get; set; }
+
+    [JsonPropertyName("url_private")]
+    public string? UrlPrivate { get; set; }
+
+    [JsonPropertyName("url_private_download")]
+    public string? UrlPrivateDownload { get; set; }
+}
+
+#endregion
+
+#region Block Kit Models
+
+/// <summary>
+/// Slack Block Kit block element
+/// </summary>
+public class SlackBlock
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("text")]
+    public SlackTextObject? Text { get; set; }
+
+    [JsonPropertyName("elements")]
+    public List<SlackBlock>? Elements { get; set; }
+
+    [JsonPropertyName("block_id")]
+    public string? BlockId { get; set; }
+}
+
+/// <summary>
+/// Slack text object used in blocks
+/// </summary>
+public class SlackTextObject
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "mrkdwn";
+
+    [JsonPropertyName("text")]
+    public string Text { get; set; } = string.Empty;
+}
+
+#endregion
+
+#region Web API Request Models
+
+/// <summary>
+/// Request body for chat.postMessage
+/// </summary>
+public class SlackPostMessageRequest
+{
+    [JsonPropertyName("channel")]
+    public string Channel { get; set; } = string.Empty;
+
+    [JsonPropertyName("text")]
+    public string? Text { get; set; }
+
+    [JsonPropertyName("blocks")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<SlackBlock>? Blocks { get; set; }
+
+    [JsonPropertyName("thread_ts")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ThreadTs { get; set; }
+
+    [JsonPropertyName("reply_broadcast")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ReplyBroadcast { get; set; }
+
+    [JsonPropertyName("mrkdwn")]
+    public bool Mrkdwn { get; set; } = true;
+
+    [JsonPropertyName("unfurl_links")]
+    public bool UnfurlLinks { get; set; }
+}
+
+#endregion
+
+#region Web API Response Models
+
+/// <summary>
+/// Standard Slack API response envelope
+/// </summary>
+public class SlackApiResponse
+{
+    [JsonPropertyName("ok")]
+    public bool Ok { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+}
+
+/// <summary>
+/// Response from chat.postMessage
+/// </summary>
+public class SlackPostMessageResponse : SlackApiResponse
+{
+    [JsonPropertyName("channel")]
+    public string? Channel { get; set; }
+
+    [JsonPropertyName("ts")]
+    public string? Ts { get; set; }
+}
+
+/// <summary>
+/// Response from auth.test (used at initialization)
+/// </summary>
+public class SlackAuthTestResponse : SlackApiResponse
+{
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+
+    [JsonPropertyName("team")]
+    public string? Team { get; set; }
+
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
+
+    [JsonPropertyName("team_id")]
+    public string? TeamId { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public string? UserId { get; set; }
+
+    [JsonPropertyName("bot_id")]
+    public string? BotId { get; set; }
+}
+
+#endregion
+
+#region Users API Response Models
+
+/// <summary>
+/// Response from users.info API (used for identity resolution)
+/// </summary>
+public class SlackUserInfoResponse : SlackApiResponse
+{
+    [JsonPropertyName("user")]
+    public SlackUserInfo? UserInfo { get; set; }
+}
+
+/// <summary>
+/// Slack user object from users.info
+/// </summary>
+public class SlackUserInfo
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("real_name")]
+    public string? RealName { get; set; }
+
+    [JsonPropertyName("profile")]
+    public SlackUserProfile? Profile { get; set; }
+
+    [JsonPropertyName("is_bot")]
+    public bool IsBot { get; set; }
+
+    [JsonPropertyName("deleted")]
+    public bool Deleted { get; set; }
+}
+
+/// <summary>
+/// Slack user profile containing email
+/// </summary>
+public class SlackUserProfile
+{
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    [JsonPropertyName("display_name")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("real_name")]
+    public string? RealName { get; set; }
+}
+
+#endregion

--- a/src/OpenDeepWiki/Chat/Providers/Slack/SlackProvider.cs
+++ b/src/OpenDeepWiki/Chat/Providers/Slack/SlackProvider.cs
@@ -1,0 +1,512 @@
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenDeepWiki.Chat.Abstractions;
+
+namespace OpenDeepWiki.Chat.Providers.Slack;
+
+/// <summary>
+/// Slack messaging Provider implementation.
+/// Uses Slack Events API for receiving messages and Web API for sending.
+/// </summary>
+public class SlackProvider : BaseMessageProvider
+{
+    private readonly HttpClient _httpClient;
+    private readonly SlackProviderOptions _slackOptions;
+    private string? _botUserId;
+
+    private static readonly HashSet<ChatMessageType> SupportedMessageTypes = new()
+    {
+        ChatMessageType.Text,
+        ChatMessageType.Image,
+        ChatMessageType.RichText,
+        ChatMessageType.Card
+    };
+
+    private static readonly HashSet<string> IgnoredSubtypes = new()
+    {
+        "bot_message", "message_changed", "message_deleted",
+        "channel_join", "channel_leave", "channel_topic",
+        "channel_purpose", "channel_name", "file_comment",
+        "channel_archive", "channel_unarchive", "group_join",
+        "group_leave", "group_topic", "group_purpose", "group_name"
+    };
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public override string PlatformId => "slack";
+    public override string DisplayName => "Slack";
+
+    public SlackProvider(
+        ILogger<SlackProvider> logger,
+        IOptions<SlackProviderOptions> options,
+        HttpClient httpClient)
+        : base(logger, options)
+    {
+        _httpClient = httpClient;
+        _slackOptions = options.Value;
+    }
+
+    /// <summary>
+    /// Initialize provider: verify bot token and resolve bot user ID.
+    /// </summary>
+    public override async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        await base.InitializeAsync(cancellationToken);
+
+        if (string.IsNullOrEmpty(_slackOptions.BotToken))
+        {
+            Logger.LogWarning("Slack BotToken not configured, provider will not be fully functional");
+            return;
+        }
+
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_slackOptions.ApiBaseUrl}/auth.test");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _slackOptions.BotToken);
+
+            var response = await _httpClient.SendAsync(request, cancellationToken);
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            var authResponse = JsonSerializer.Deserialize<SlackAuthTestResponse>(content);
+
+            if (authResponse?.Ok == true)
+            {
+                _botUserId = authResponse.UserId;
+                Logger.LogInformation("Slack provider initialized. Bot user: {User} ({UserId})",
+                    authResponse.User, _botUserId);
+            }
+            else
+            {
+                Logger.LogError("Slack auth.test failed: {Error}", authResponse?.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to initialize Slack provider");
+        }
+    }
+
+    /// <summary>
+    /// Validate Slack webhook requests using HMAC-SHA256 signature verification.
+    /// Also handles the url_verification challenge for initial app setup.
+    /// </summary>
+    public override async Task<WebhookValidationResult> ValidateWebhookAsync(
+        HttpRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            request.EnableBuffering();
+            using var reader = new StreamReader(request.Body, Encoding.UTF8, leaveOpen: true);
+            var body = await reader.ReadToEndAsync(cancellationToken);
+            request.Body.Position = 0;
+
+            // Parse body to check for url_verification challenge
+            var envelope = JsonSerializer.Deserialize<SlackEventEnvelope>(body);
+            if (envelope?.Type == "url_verification")
+            {
+                return new WebhookValidationResult(true, Challenge: envelope.Challenge);
+            }
+
+            // Verify request signature
+            if (string.IsNullOrEmpty(_slackOptions.SigningSecret))
+            {
+                Logger.LogWarning("Slack SigningSecret not configured, skipping signature verification");
+                return new WebhookValidationResult(true);
+            }
+
+            var timestamp = request.Headers["X-Slack-Request-Timestamp"].FirstOrDefault();
+            var signature = request.Headers["X-Slack-Signature"].FirstOrDefault();
+
+            if (string.IsNullOrEmpty(timestamp) || string.IsNullOrEmpty(signature))
+            {
+                return new WebhookValidationResult(false,
+                    ErrorMessage: "Missing X-Slack-Request-Timestamp or X-Slack-Signature headers");
+            }
+
+            // Reject requests older than tolerance (replay attack prevention)
+            if (long.TryParse(timestamp, out var ts))
+            {
+                var requestAge = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - ts;
+                if (Math.Abs(requestAge) > _slackOptions.WebhookTimestampToleranceSeconds)
+                {
+                    return new WebhookValidationResult(false,
+                        ErrorMessage: "Request timestamp too old");
+                }
+            }
+
+            // Compute expected signature: v0=HMAC-SHA256(signing_secret, "v0:{timestamp}:{body}")
+            var sigBasestring = $"v0:{timestamp}:{body}";
+            var computedSignature = ComputeSignature(_slackOptions.SigningSecret, sigBasestring);
+
+            if (!CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(computedSignature),
+                Encoding.UTF8.GetBytes(signature)))
+            {
+                return new WebhookValidationResult(false, ErrorMessage: "Invalid signature");
+            }
+
+            return new WebhookValidationResult(true);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to validate Slack webhook");
+            return new WebhookValidationResult(false, ErrorMessage: ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Parse Slack Events API event_callback payloads into unified IChatMessage format.
+    /// </summary>
+    public override Task<IChatMessage?> ParseMessageAsync(
+        string rawMessage,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var envelope = JsonSerializer.Deserialize<SlackEventEnvelope>(rawMessage);
+            if (envelope == null)
+            {
+                Logger.LogWarning("Failed to deserialize Slack event envelope");
+                return Task.FromResult<IChatMessage?>(null);
+            }
+
+            // Only process event_callback type
+            if (envelope.Type != "event_callback")
+            {
+                Logger.LogDebug("Ignoring non-event_callback: {Type}", envelope.Type);
+                return Task.FromResult<IChatMessage?>(null);
+            }
+
+            var evt = envelope.Event;
+            if (evt == null)
+            {
+                Logger.LogWarning("No event content in Slack envelope");
+                return Task.FromResult<IChatMessage?>(null);
+            }
+
+            // Event type filtering:
+            // - app_mention: always process (channel @mentions)
+            // - message: only process for DMs (im/mpim), skip for channels
+            //   (channels already send app_mention, processing both causes duplicates)
+            if (evt.Type == "message" && evt.ChannelType is "channel" or "group")
+            {
+                Logger.LogDebug("Ignoring message event in channel (app_mention handles these): {Channel}", evt.Channel);
+                return Task.FromResult<IChatMessage?>(null);
+            }
+
+            if (evt.Type != "message" && evt.Type != "app_mention")
+            {
+                Logger.LogDebug("Ignoring event type: {Type}", evt.Type);
+                return Task.FromResult<IChatMessage?>(null);
+            }
+
+            // Filter out bot's own messages
+            if (!string.IsNullOrEmpty(evt.BotId))
+            {
+                Logger.LogDebug("Ignoring bot message from bot_id: {BotId}", evt.BotId);
+                return Task.FromResult<IChatMessage?>(null);
+            }
+
+            if (!string.IsNullOrEmpty(_botUserId) && evt.User == _botUserId)
+            {
+                Logger.LogDebug("Ignoring own bot message");
+                return Task.FromResult<IChatMessage?>(null);
+            }
+
+            // Filter out non-content subtypes
+            if (!string.IsNullOrEmpty(evt.Subtype) && IgnoredSubtypes.Contains(evt.Subtype))
+            {
+                Logger.LogDebug("Ignoring message subtype: {Subtype}", evt.Subtype);
+                return Task.FromResult<IChatMessage?>(null);
+            }
+
+            // Determine message type and content
+            var (messageType, content) = ParseSlackMessageContent(evt);
+
+            // Build metadata including thread context
+            var metadata = new Dictionary<string, object>
+            {
+                { "channel", evt.Channel ?? string.Empty },
+                { "channel_type", evt.ChannelType ?? string.Empty },
+                { "event_type", evt.Type },
+                { "team_id", envelope.TeamId ?? string.Empty },
+                { "event_id", envelope.EventId ?? string.Empty }
+            };
+
+            // Thread context for reply routing
+            if (!string.IsNullOrEmpty(evt.ThreadTs))
+            {
+                metadata["thread_ts"] = evt.ThreadTs;
+            }
+            else if (!string.IsNullOrEmpty(evt.Ts))
+            {
+                // Top-level message: use ts as potential thread parent
+                metadata["message_ts"] = evt.Ts;
+            }
+
+            IChatMessage result = new ChatMessage
+            {
+                MessageId = envelope.EventId ?? evt.Ts ?? Guid.NewGuid().ToString(),
+                SenderId = evt.User ?? string.Empty,
+                ReceiverId = evt.Channel,
+                Content = content,
+                MessageType = messageType,
+                Platform = PlatformId,
+                Timestamp = ParseSlackTimestamp(evt.Ts),
+                Metadata = metadata
+            };
+
+            return Task.FromResult<IChatMessage?>(result);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to parse Slack message");
+            return Task.FromResult<IChatMessage?>(null);
+        }
+    }
+
+    /// <summary>
+    /// Send a message to Slack via chat.postMessage Web API.
+    /// </summary>
+    public override async Task<SendResult> SendMessageAsync(
+        IChatMessage message,
+        string targetUserId,
+        CancellationToken cancellationToken = default)
+    {
+        return await SendWithRetryAsync(async () =>
+        {
+            var processedMessage = DegradeMessage(message, SupportedMessageTypes);
+
+            var postRequest = new SlackPostMessageRequest
+            {
+                Channel = targetUserId
+            };
+
+            // Handle thread replies
+            if (_slackOptions.ReplyInThread && message.Metadata != null)
+            {
+                if (message.Metadata.TryGetValue("thread_ts", out var threadTs))
+                {
+                    postRequest.ThreadTs = threadTs.ToString();
+                }
+                else if (message.Metadata.TryGetValue("message_ts", out var messageTs))
+                {
+                    postRequest.ThreadTs = messageTs.ToString();
+                }
+            }
+
+            // Convert message content based on type
+            switch (processedMessage.MessageType)
+            {
+                case ChatMessageType.Card:
+                case ChatMessageType.RichText:
+                    try
+                    {
+                        var blocks = JsonSerializer.Deserialize<List<SlackBlock>>(processedMessage.Content);
+                        postRequest.Blocks = blocks;
+                        postRequest.Text = string.Empty; // Fallback text required by Slack
+                    }
+                    catch
+                    {
+                        // If blocks parsing fails, send as text
+                        postRequest.Text = processedMessage.Content;
+                    }
+                    break;
+
+                case ChatMessageType.Text:
+                default:
+                    postRequest.Text = processedMessage.Content;
+                    break;
+            }
+
+            var url = $"{_slackOptions.ApiBaseUrl}/chat.postMessage";
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(postRequest, SerializerOptions),
+                    Encoding.UTF8,
+                    "application/json")
+            };
+            httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _slackOptions.BotToken);
+
+            var response = await _httpClient.SendAsync(httpRequest, cancellationToken);
+            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            var apiResponse = JsonSerializer.Deserialize<SlackPostMessageResponse>(responseContent);
+
+            if (apiResponse?.Ok == true)
+            {
+                return new SendResult(true, apiResponse.Ts);
+            }
+
+            var shouldRetry = IsRetryableError(apiResponse?.Error, response.StatusCode);
+            return new SendResult(
+                false,
+                ErrorCode: apiResponse?.Error ?? response.StatusCode.ToString(),
+                ErrorMessage: apiResponse?.Error,
+                ShouldRetry: shouldRetry);
+        }, cancellationToken);
+    }
+
+    #region Private methods
+
+    private static (ChatMessageType Type, string Content) ParseSlackMessageContent(SlackEvent evt)
+    {
+        // If message has image files, treat as Image type
+        if (evt.Files != null && evt.Files.Count > 0)
+        {
+            var firstFile = evt.Files[0];
+            if (firstFile.Mimetype?.StartsWith("image/") == true)
+            {
+                return (ChatMessageType.Image, firstFile.UrlPrivate ?? firstFile.Id);
+            }
+            return (ChatMessageType.File, firstFile.UrlPrivate ?? firstFile.Id);
+        }
+
+        return (ChatMessageType.Text, evt.Text ?? string.Empty);
+    }
+
+    private static DateTimeOffset ParseSlackTimestamp(string? ts)
+    {
+        // Slack timestamps are Unix epoch with microseconds: "1234567890.123456"
+        if (!string.IsNullOrEmpty(ts) && double.TryParse(ts,
+            NumberStyles.Any,
+            CultureInfo.InvariantCulture,
+            out var unixTimestamp))
+        {
+            return DateTimeOffset.FromUnixTimeMilliseconds((long)(unixTimestamp * 1000));
+        }
+        return DateTimeOffset.UtcNow;
+    }
+
+    private static string ComputeSignature(string signingSecret, string basestring)
+    {
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(signingSecret));
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(basestring));
+        return $"v0={Convert.ToHexString(hash).ToLowerInvariant()}";
+    }
+
+    private static bool IsRetryableError(string? error, System.Net.HttpStatusCode statusCode)
+    {
+        if (statusCode == System.Net.HttpStatusCode.TooManyRequests)
+            return true;
+
+        return error switch
+        {
+            "ratelimited" => true,
+            "service_unavailable" => true,
+            "request_timeout" => true,
+            "internal_error" => true,
+            "fatal_error" => true,
+            _ => false
+        };
+    }
+
+    private async Task<SendResult> SendWithRetryAsync(
+        Func<Task<SendResult>> sendFunc,
+        CancellationToken cancellationToken)
+    {
+        var maxRetries = _slackOptions.MaxRetryCount;
+        var retryDelayBase = _slackOptions.RetryDelayBase;
+
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
+        {
+            try
+            {
+                var result = await sendFunc();
+
+                if (result.Success || !result.ShouldRetry || attempt >= maxRetries)
+                    return result;
+
+                var delay = retryDelayBase * (int)Math.Pow(2, attempt);
+                Logger.LogWarning(
+                    "Slack API call failed (attempt {Attempt}/{MaxRetries}), retrying in {Delay}ms. Error: {Error}",
+                    attempt + 1, maxRetries + 1, delay, result.ErrorMessage);
+
+                await Task.Delay(delay, cancellationToken);
+            }
+            catch (Exception ex) when (attempt < maxRetries)
+            {
+                var delay = retryDelayBase * (int)Math.Pow(2, attempt);
+                Logger.LogWarning(ex,
+                    "Slack API call threw exception (attempt {Attempt}/{MaxRetries}), retrying in {Delay}ms",
+                    attempt + 1, maxRetries + 1, delay);
+
+                await Task.Delay(delay, cancellationToken);
+            }
+        }
+
+        return new SendResult(false, ErrorCode: "MAX_RETRIES_EXCEEDED",
+            ErrorMessage: "Maximum retry attempts exceeded");
+    }
+
+    #endregion
+
+    #region Block Kit helper methods
+
+    /// <summary>
+    /// Create a simple markdown text message using Block Kit section block
+    /// </summary>
+    public static string CreateTextBlocks(string text)
+    {
+        var blocks = new List<SlackBlock>
+        {
+            new()
+            {
+                Type = "section",
+                Text = new SlackTextObject
+                {
+                    Type = "mrkdwn",
+                    Text = text
+                }
+            }
+        };
+        return JsonSerializer.Serialize(blocks);
+    }
+
+    /// <summary>
+    /// Create a multi-section message with a header and dividers
+    /// </summary>
+    public static string CreateMultiSectionBlocks(string header, IEnumerable<string> sections)
+    {
+        var blocks = new List<SlackBlock>
+        {
+            new()
+            {
+                Type = "header",
+                Text = new SlackTextObject
+                {
+                    Type = "plain_text",
+                    Text = header
+                }
+            }
+        };
+
+        foreach (var section in sections)
+        {
+            blocks.Add(new SlackBlock { Type = "divider" });
+            blocks.Add(new SlackBlock
+            {
+                Type = "section",
+                Text = new SlackTextObject
+                {
+                    Type = "mrkdwn",
+                    Text = section
+                }
+            });
+        }
+
+        return JsonSerializer.Serialize(blocks);
+    }
+
+    #endregion
+}

--- a/src/OpenDeepWiki/Chat/Providers/Slack/SlackProviderOptions.cs
+++ b/src/OpenDeepWiki/Chat/Providers/Slack/SlackProviderOptions.cs
@@ -1,0 +1,43 @@
+namespace OpenDeepWiki.Chat.Providers.Slack;
+
+/// <summary>
+/// Slack Provider configuration options
+/// </summary>
+public class SlackProviderOptions : ProviderOptions
+{
+    /// <summary>
+    /// Slack Bot Token (xoxb-...)
+    /// Used for all Slack Web API calls (chat.postMessage, etc.)
+    /// Long-lived token that does not expire.
+    /// </summary>
+    public string BotToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Slack Signing Secret
+    /// Used to verify incoming webhook requests via HMAC-SHA256
+    /// </summary>
+    public string SigningSecret { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Slack App-level Token (xapp-..., optional)
+    /// Only needed for Socket Mode; not required for HTTP webhook mode
+    /// </summary>
+    public string? AppLevelToken { get; set; }
+
+    /// <summary>
+    /// Slack Web API base URL
+    /// </summary>
+    public string ApiBaseUrl { get; set; } = "https://slack.com/api";
+
+    /// <summary>
+    /// Whether to reply in threads when the incoming message is in a channel.
+    /// Keeps conversations organized and reduces channel noise.
+    /// </summary>
+    public bool ReplyInThread { get; set; } = true;
+
+    /// <summary>
+    /// Maximum age in seconds for webhook request timestamps.
+    /// Slack recommends rejecting requests older than 5 minutes to prevent replay attacks.
+    /// </summary>
+    public int WebhookTimestampToleranceSeconds { get; set; } = 300;
+}

--- a/src/OpenDeepWiki/Endpoints/ChatEndpoints.cs
+++ b/src/OpenDeepWiki/Endpoints/ChatEndpoints.cs
@@ -65,6 +65,12 @@ public static class ChatEndpoints
             .WithSummary("微信客服消息 Webhook")
             .AllowAnonymous();
         
+        // Slack Webhook
+        app.MapPost("/slack", HandleSlackWebhookAsync)
+            .WithName("SlackWebhook")
+            .WithSummary("Slack message Webhook")
+            .AllowAnonymous();
+
         // 通用 Webhook（根据平台参数路由）
         app.MapPost("/{platform}", HandleGenericWebhookAsync)
             .WithName("GenericWebhook")
@@ -194,6 +200,17 @@ public static class ChatEndpoints
         return await HandlePlatformWebhookAsync("wechat", httpContext, messageRouter, logger);
     }
     
+    /// <summary>
+    /// Handle Slack Webhook
+    /// </summary>
+    private static async Task<IResult> HandleSlackWebhookAsync(
+        HttpContext httpContext,
+        [FromServices] IMessageRouter messageRouter,
+        [FromServices] ILogger<ChatEndpointsLogger> logger)
+    {
+        return await HandlePlatformWebhookAsync("slack", httpContext, messageRouter, logger);
+    }
+
     /// <summary>
     /// 处理通用 Webhook
     /// </summary>

--- a/src/OpenDeepWiki/Services/Chat/ChatWebhookApiService.cs
+++ b/src/OpenDeepWiki/Services/Chat/ChatWebhookApiService.cs
@@ -64,6 +64,16 @@ public class ChatWebhookApiService(IMessageRouter messageRouter, ILogger<ChatWeb
     }
 
     /// <summary>
+    /// Slack Webhook
+    /// </summary>
+    [HttpPost("/slack")]
+    [AllowAnonymous]
+    public Task<IResult> HandleSlackWebhookAsync(HttpContext httpContext)
+    {
+        return HandlePlatformWebhookAsync("slack", httpContext);
+    }
+
+    /// <summary>
     /// 通用 Webhook
     /// </summary>
     [HttpPost("/{platform}")]

--- a/src/OpenDeepWiki/appsettings.json
+++ b/src/OpenDeepWiki/appsettings.json
@@ -53,5 +53,21 @@
     "RetryBaseDelayMs": 1000,
     "ManualTriggerPriority": 100
   },
+  "Chat": {
+    "Providers": {
+      "Slack": {
+        "Enabled": false,
+        "BotToken": "",
+        "SigningSecret": "",
+        "ApiBaseUrl": "https://slack.com/api",
+        "ReplyInThread": true,
+        "WebhookTimestampToleranceSeconds": 300,
+        "MessageInterval": 1000,
+        "MaxRetryCount": 3,
+        "RetryDelayBase": 1000,
+        "RequestTimeout": 30
+      }
+    }
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
Adds Slack as a new messaging provider alongside the existing Feishu, QQ, and WeChat providers. This enables users to interact with OpenDeepWiki documentation through Slack DMs and channel @mentions.

## What's included

### Slack Provider (`Chat/Providers/Slack/`)
- **SlackProvider.cs** - Full provider implementation extending `BaseMessageProvider`
  - Events API webhook with HMAC-SHA256 request signature verification
  - Handles `app_mention` (channels) and `message` (DMs) events
  - Threaded replies to reduce channel noise
  - Automatic deduplication of channel events (Slack sends both `app_mention` and `message`)
- **SlackModels.cs** - Slack API DTOs (Events API, Block Kit, Web API requests/responses)
- **SlackProviderOptions.cs** - Configuration (BotToken, SigningSecret, threading, timeouts)

### User Identity Mapping (`Chat/Execution/ChatUserResolver.cs`)
- Maps Slack user IDs to OpenDeepWiki users via email matching
- Calls Slack `users.info` API to resolve email, then looks up in Users table
- Singleton with 30-minute in-memory cache
- Enables permission-aware access: mapped users see public + department-assigned private repos

### Multi-Repo Documentation Tool (`Agents/Tools/ChatMultiRepoDocTool.cs`)
- New AI tool for messaging providers to query documentation across all accessible repositories
- Permission-aware: filters repos based on user's department assignments
- Three tools: `ListRepositories`, `ListDocuments`, `ReadDoc`

### Enhanced Agent Executor
- Updated `AgentExecutor` to use DeepWiki documentation tools and system prompt
- Resolves user identity before creating tools for permission scoping

### Registration & Endpoints
- Slack webhook endpoint at `POST /api/chat/webhook/slack`
- DI registration in `ChatServiceExtensions.cs`
- Default configuration in `appsettings.json`

## Slack App Setup
Required bot event subscriptions: `message.channels`, `message.groups`, `message.im`, `app_mention`
Required OAuth scopes: `chat:write`, `channels:history`, `groups:history`, `im:history`, `users:read.email`