### PR TITLE
Add integrations dialog to home page

### DIFF
--- a/web/app/(main)/page.tsx
+++ b/web/app/(main)/page.tsx
@@ -6,6 +6,7 @@ import { AppLayout } from "@/components/app-layout";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Search, Plus, Flame, Puzzle } from "lucide-react";
+import { IntegrationsDialog } from "@/components/integrations-dialog";
 import { useTranslations } from "@/hooks/use-translations";
 import { RepositorySubmitForm } from "@/components/repo/repository-submit-form";
 import {
@@ -23,6 +24,7 @@ export default function Home() {
   const { user } = useAuth();
   const [activeItem, setActiveItem] = useState(t("sidebar.explore"));
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [isIntegrationsOpen, setIsIntegrationsOpen] = useState(false);
   const [keyword, setKeyword] = useState("");
   const { isScrolled } = useScrollPosition(100);
 
@@ -100,11 +102,19 @@ export default function Home() {
               </Button>
             </div>
             <div className="flex justify-center">
-              <Button variant="ghost" className="gap-2 text-muted-foreground hover:text-foreground">
+              <Button
+                variant="ghost"
+                className="gap-2 text-muted-foreground hover:text-foreground"
+                onClick={() => setIsIntegrationsOpen(true)}
+              >
                 <Puzzle className="h-4 w-4" />
                 {t("home.mcpIntegration")}
               </Button>
             </div>
+            <IntegrationsDialog
+              open={isIntegrationsOpen}
+              onOpenChange={setIsIntegrationsOpen}
+            />
           </div>
         </div>
 

--- a/web/components/integrations-dialog.tsx
+++ b/web/components/integrations-dialog.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useTranslations } from "@/hooks/use-translations";
+import { useAuth } from "@/contexts/auth-context";
+import { getChatProviderConfigs } from "@/lib/admin-api";
+import {
+  Copy,
+  Check,
+  ExternalLink,
+  MessageSquare,
+  Server,
+  CheckCircle,
+  XCircle,
+  Loader2,
+} from "lucide-react";
+import Link from "next/link";
+
+interface IntegrationsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function IntegrationsDialog({ open, onOpenChange }: IntegrationsDialogProps) {
+  const t = useTranslations();
+  const { user } = useAuth();
+  const isAdmin = user?.roles?.includes("Admin") ?? false;
+
+  const [slackLoading, setSlackLoading] = useState(false);
+  const [slackConnected, setSlackConnected] = useState(false);
+  const [slackError, setSlackError] = useState(false);
+  const [mcpUrlCopied, setMcpUrlCopied] = useState(false);
+  const [configCopied, setConfigCopied] = useState(false);
+
+  const mcpUrl = typeof window !== "undefined" ? `${window.location.origin}/api/mcp` : "/api/mcp";
+
+  const claudeDesktopConfig = JSON.stringify(
+    {
+      mcpServers: {
+        deepwiki: {
+          url: mcpUrl,
+        },
+      },
+    },
+    null,
+    2
+  );
+
+  useEffect(() => {
+    if (!open) return;
+
+    setSlackLoading(true);
+    setSlackError(false);
+    setSlackConnected(false);
+
+    getChatProviderConfigs()
+      .then((providers) => {
+        const slack = providers.find((p) => p.platform === "slack");
+        setSlackConnected(slack ? slack.isEnabled && slack.isRegistered : false);
+      })
+      .catch(() => {
+        setSlackError(true);
+      })
+      .finally(() => {
+        setSlackLoading(false);
+      });
+  }, [open]);
+
+  const copyToClipboard = useCallback(async (text: string, type: "url" | "config") => {
+    try {
+      await navigator.clipboard.writeText(text);
+      if (type === "url") {
+        setMcpUrlCopied(true);
+        setTimeout(() => setMcpUrlCopied(false), 2000);
+      } else {
+        setConfigCopied(true);
+        setTimeout(() => setConfigCopied(false), 2000);
+      }
+    } catch {
+      // Clipboard API not available
+    }
+  }, []);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{t("home.integrations.title")}</DialogTitle>
+          <DialogDescription>{t("home.integrations.description")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 pt-2">
+          {/* Slack Integration Section */}
+          <div className="rounded-lg border p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <MessageSquare className="h-5 w-5 text-muted-foreground" />
+                <h3 className="font-medium">{t("home.integrations.slack.title")}</h3>
+              </div>
+              <div className="flex items-center gap-1.5">
+                {slackLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                ) : slackConnected ? (
+                  <>
+                    <CheckCircle className="h-4 w-4 text-green-500" />
+                    <span className="text-sm text-green-500">{t("home.integrations.slack.connected")}</span>
+                  </>
+                ) : (
+                  <>
+                    <XCircle className="h-4 w-4 text-muted-foreground" />
+                    <span className="text-sm text-muted-foreground">{t("home.integrations.slack.notConnected")}</span>
+                  </>
+                )}
+              </div>
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {isAdmin ? (
+                <Link
+                  href="/admin/chat-providers"
+                  className="inline-flex items-center gap-1 text-primary hover:underline"
+                  onClick={() => onOpenChange(false)}
+                >
+                  {t("home.integrations.slack.configure")}
+                  <ExternalLink className="h-3 w-3" />
+                </Link>
+              ) : (
+                <p>{t("home.integrations.slack.contactAdmin")}</p>
+              )}
+            </div>
+          </div>
+
+          {/* MCP Server Section */}
+          <div className="rounded-lg border p-4 space-y-3">
+            <div className="flex items-center gap-2">
+              <Server className="h-5 w-5 text-muted-foreground" />
+              <h3 className="font-medium">{t("home.integrations.mcp.title")}</h3>
+            </div>
+            <p className="text-sm text-muted-foreground">{t("home.integrations.mcp.description")}</p>
+
+            {/* MCP URL */}
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                {t("home.integrations.mcp.serverUrl")}
+              </label>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">
+                  {mcpUrl}
+                </code>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="shrink-0 gap-1.5"
+                  onClick={() => copyToClipboard(mcpUrl, "url")}
+                >
+                  {mcpUrlCopied ? (
+                    <>
+                      <Check className="h-3.5 w-3.5" />
+                      {t("home.integrations.mcp.copied")}
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-3.5 w-3.5" />
+                      {t("home.integrations.mcp.copyUrl")}
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+
+            {/* Claude Desktop Config */}
+            <div className="space-y-1.5">
+              <p className="text-sm text-muted-foreground">
+                {t("home.integrations.mcp.claudeDesktopHint")}
+              </p>
+              <div className="relative">
+                <pre className="rounded-md bg-muted px-3 py-2 text-xs font-mono overflow-x-auto">
+                  {claudeDesktopConfig}
+                </pre>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="absolute top-1.5 right-1.5 h-7 gap-1 text-xs"
+                  onClick={() => copyToClipboard(claudeDesktopConfig, "config")}
+                >
+                  {configCopied ? (
+                    <>
+                      <Check className="h-3 w-3" />
+                      {t("home.integrations.mcp.copied")}
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-3 w-3" />
+                      {t("home.integrations.mcp.copyConfig")}
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+
+            {/* Claude.ai Hint */}
+            <p className="text-sm text-muted-foreground">
+              {t("home.integrations.mcp.claudeAiHint")}
+            </p>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/i18n/messages/en/home.json
+++ b/web/i18n/messages/en/home.json
@@ -37,6 +37,27 @@
   },
   "exploreTrending": "Explore This Week's Trending Repos",
   "mcpIntegration": "Integrate KeboolaDeepWiki MCP into your dev tools 🔥",
+  "integrations": {
+    "title": "Integrations",
+    "description": "Connect DeepWiki with your development tools",
+    "slack": {
+      "title": "Slack Integration",
+      "connected": "Connected",
+      "notConnected": "Not connected",
+      "configure": "Configure Slack",
+      "contactAdmin": "Contact your administrator to configure Slack integration."
+    },
+    "mcp": {
+      "title": "MCP Server",
+      "description": "Use DeepWiki as an MCP server in your AI tools.",
+      "serverUrl": "Server URL",
+      "copied": "Copied!",
+      "copyUrl": "Copy URL",
+      "copyConfig": "Copy config",
+      "claudeDesktopHint": "Add this to your Claude Desktop configuration file (claude_desktop_config.json):",
+      "claudeAiHint": "In Claude.ai settings, add the MCP server URL above as a remote MCP server."
+    }
+  },
   "private": {
     "visibility": {
       "public": "Public",

--- a/web/i18n/messages/ja/home.json
+++ b/web/i18n/messages/ja/home.json
@@ -37,6 +37,27 @@
   },
   "exploreTrending": "今週のトレンドリポジトリを探索",
   "mcpIntegration": "KeboolaDeepWiki MCPを開発ツールに統合 🔥",
+  "integrations": {
+    "title": "統合",
+    "description": "DeepWikiを開発ツールと接続",
+    "slack": {
+      "title": "Slack連携",
+      "connected": "接続済み",
+      "notConnected": "未接続",
+      "configure": "Slackを設定",
+      "contactAdmin": "Slack連携の設定については管理者にお問い合わせください。"
+    },
+    "mcp": {
+      "title": "MCPサーバー",
+      "description": "AIツールでDeepWikiをMCPサーバーとして使用できます。",
+      "serverUrl": "サーバーURL",
+      "copied": "コピーしました！",
+      "copyUrl": "URLをコピー",
+      "copyConfig": "設定をコピー",
+      "claudeDesktopHint": "Claude Desktopの設定ファイル (claude_desktop_config.json) に以下を追加してください：",
+      "claudeAiHint": "Claude.aiの設定で、上記のMCPサーバーURLをリモートMCPサーバーとして追加してください。"
+    }
+  },
   "private": {
     "visibility": {
       "public": "公開",

--- a/web/i18n/messages/ko/home.json
+++ b/web/i18n/messages/ko/home.json
@@ -37,6 +37,27 @@
   },
   "exploreTrending": "이번 주 인기 저장소 탐색",
   "mcpIntegration": "개발 도구에 KeboolaDeepWiki MCP 통합 🔥",
+  "integrations": {
+    "title": "통합",
+    "description": "DeepWiki를 개발 도구와 연결",
+    "slack": {
+      "title": "Slack 통합",
+      "connected": "연결됨",
+      "notConnected": "연결되지 않음",
+      "configure": "Slack 구성",
+      "contactAdmin": "Slack 통합을 구성하려면 관리자에게 문의하세요."
+    },
+    "mcp": {
+      "title": "MCP 서버",
+      "description": "AI 도구에서 DeepWiki를 MCP 서버로 사용하세요.",
+      "serverUrl": "서버 URL",
+      "copied": "복사됨!",
+      "copyUrl": "URL 복사",
+      "copyConfig": "설정 복사",
+      "claudeDesktopHint": "Claude Desktop 설정 파일 (claude_desktop_config.json)에 다음을 추가하세요:",
+      "claudeAiHint": "Claude.ai 설정에서 위의 MCP 서버 URL을 원격 MCP 서버로 추가하세요."
+    }
+  },
   "private": {
     "visibility": {
       "public": "공개",

--- a/web/i18n/messages/zh/home.json
+++ b/web/i18n/messages/zh/home.json
@@ -37,6 +37,27 @@
   },
   "exploreTrending": "探索本周的 热门仓库",
   "mcpIntegration": "把 KeboolaDeepWiki MCP 接入你的开发工具 🔥",
+  "integrations": {
+    "title": "集成",
+    "description": "将 DeepWiki 与您的开发工具连接",
+    "slack": {
+      "title": "Slack 集成",
+      "connected": "已连接",
+      "notConnected": "未连接",
+      "configure": "配置 Slack",
+      "contactAdmin": "请联系管理员配置 Slack 集成。"
+    },
+    "mcp": {
+      "title": "MCP 服务器",
+      "description": "在您的 AI 工具中将 DeepWiki 用作 MCP 服务器。",
+      "serverUrl": "服务器地址",
+      "copied": "已复制！",
+      "copyUrl": "复制地址",
+      "copyConfig": "复制配置",
+      "claudeDesktopHint": "将以下内容添加到您的 Claude Desktop 配置文件 (claude_desktop_config.json)：",
+      "claudeAiHint": "在 Claude.ai 设置中，将上方的 MCP 服务器地址添加为远程 MCP 服务器。"
+    }
+  },
   "private": {
     "visibility": {
       "public": "公开",


### PR DESCRIPTION
## Summary
Make the "Integrate MCP" button on the dashboard open a modal dialog with two sections:

- **Slack Integration**: Dynamic status detection via chat provider API. Shows connected/not-connected status. Admins see a link to the configuration page, non-admins see a "contact administrator" message.
- **MCP Server**: Shows the dynamically constructed MCP server URL with a copy-to-clipboard button, a Claude Desktop JSON config snippet with copy button, and a Claude.ai setup hint.

Full i18n support for all 4 locales (en, zh, ko, ja).

## Changes
- New `web/components/integrations-dialog.tsx` component
- Modified `web/app/(main)/page.tsx` to wire up the dialog
- Added `home.integrations.*` translation keys to all 4 locale files

## Test plan
- Click "Integrate MCP" button on home page -- modal opens
- Verify Slack status detection works (connected/not connected)
- Verify MCP URL matches current origin `/api/mcp`
- Test copy buttons for URL and config snippet
- Admin vs non-admin flow for Slack section
- All 4 locales render correctly