### PR TITLE
Add unified dashboard with dual icons, sub-filters, and organization repository management

### DIFF
--- a/src/OpenDeepWiki/Endpoints/OrganizationEndpoints.cs
+++ b/src/OpenDeepWiki/Endpoints/OrganizationEndpoints.cs
@@ -33,17 +33,77 @@ public static class OrganizationEndpoints
         // 获取当前用户部门下的仓库列表
         group.MapGet("/my-repositories", async (
             ClaimsPrincipal user,
+            [FromServices] IOrganizationService orgService,
+            [FromQuery] bool? includeRestricted) =>
+        {
+            var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrEmpty(userId))
+                return Results.Unauthorized();
+
+            var result = await orgService.GetDepartmentRepositoriesAsync(userId, includeRestricted ?? false);
+            return Results.Ok(new { success = true, data = result });
+        })
+        .WithName("GetMyDepartmentRepositories")
+        .WithSummary("Get repository list for current user's departments");
+
+        // Share a repository with current user's departments
+        group.MapPost("/my-repositories/{repositoryId}/share", async (
+            string repositoryId,
+            ClaimsPrincipal user,
             [FromServices] IOrganizationService orgService) =>
         {
             var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
             if (string.IsNullOrEmpty(userId))
                 return Results.Unauthorized();
 
-            var result = await orgService.GetDepartmentRepositoriesAsync(userId);
-            return Results.Ok(new { success = true, data = result });
+            var result = await orgService.ShareRepositoryWithMyDepartmentsAsync(userId, repositoryId);
+            return Results.Ok(new { success = result });
         })
-        .WithName("GetMyDepartmentRepositories")
-        .WithSummary("获取当前用户部门下的仓库列表");
+        .WithName("ShareRepositoryWithMyDepartments")
+        .WithSummary("Share a repository with current user's departments");
+
+        // Unshare a repository from current user's departments
+        group.MapDelete("/my-repositories/{repositoryId}/share", async (
+            string repositoryId,
+            ClaimsPrincipal user,
+            [FromServices] IOrganizationService orgService) =>
+        {
+            var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrEmpty(userId))
+                return Results.Unauthorized();
+
+            var result = await orgService.UnshareRepositoryFromMyDepartmentsAsync(userId, repositoryId);
+            return Results.Ok(new { success = result });
+        })
+        .WithName("UnshareRepositoryFromMyDepartments")
+        .WithSummary("Unshare a repository from current user's departments");
+
+        // Admin-only endpoints for repository restriction
+        var adminGroup = group.MapGroup("/repositories").RequireAuthorization("AdminOnly");
+
+        adminGroup.MapPost("/{repositoryId}/restrict", async (
+            string repositoryId,
+            ClaimsPrincipal user,
+            [FromServices] IOrganizationService orgService) =>
+        {
+            var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrEmpty(userId)) return Results.Unauthorized();
+
+            var result = await orgService.RestrictRepositoryInDepartmentsAsync(repositoryId, userId);
+            return result ? Results.Ok(new { success = true }) : Results.BadRequest(new { success = false });
+        }).WithName("RestrictRepository");
+
+        adminGroup.MapPost("/{repositoryId}/unrestrict", async (
+            string repositoryId,
+            ClaimsPrincipal user,
+            [FromServices] IOrganizationService orgService) =>
+        {
+            var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrEmpty(userId)) return Results.Unauthorized();
+
+            var result = await orgService.UnrestrictRepositoryInDepartmentsAsync(repositoryId, userId);
+            return result ? Results.Ok(new { success = true }) : Results.BadRequest(new { success = false });
+        }).WithName("UnrestrictRepository");
 
         return app;
     }

--- a/src/OpenDeepWiki/Services/Organizations/IOrganizationService.cs
+++ b/src/OpenDeepWiki/Services/Organizations/IOrganizationService.cs
@@ -8,7 +8,11 @@ namespace OpenDeepWiki.Services.Organizations;
 public interface IOrganizationService
 {
     Task<List<UserDepartmentInfo>> GetUserDepartmentsAsync(string userId);
-    Task<List<DepartmentRepositoryInfo>> GetDepartmentRepositoriesAsync(string userId);
+    Task<List<DepartmentRepositoryInfo>> GetDepartmentRepositoriesAsync(string userId, bool includeRestricted = false);
+    Task<bool> ShareRepositoryWithMyDepartmentsAsync(string userId, string repositoryId);
+    Task<bool> UnshareRepositoryFromMyDepartmentsAsync(string userId, string repositoryId);
+    Task<bool> RestrictRepositoryInDepartmentsAsync(string repositoryId, string adminUserId);
+    Task<bool> UnrestrictRepositoryInDepartmentsAsync(string repositoryId, string adminUserId);
 }
 
 /// <summary>
@@ -35,4 +39,12 @@ public class DepartmentRepositoryInfo
     public string StatusName { get; set; } = string.Empty;
     public string DepartmentId { get; set; } = string.Empty;
     public string DepartmentName { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public string? PrimaryLanguage { get; set; }
+    public bool IsRestricted { get; set; }
+    /// <summary>
+    /// Whether the repository is publicly accessible. Used by frontend to show
+    /// dual icons (public + org) for repos that are both public and department-assigned.
+    /// </summary>
+    public bool IsPublic { get; set; }
 }

--- a/src/OpenDeepWiki/Services/Organizations/OrganizationService.cs
+++ b/src/OpenDeepWiki/Services/Organizations/OrganizationService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using OpenDeepWiki.EFCore;
+using OpenDeepWiki.Entities;
 
 namespace OpenDeepWiki.Services.Organizations;
 
@@ -37,7 +38,7 @@ public class OrganizationService : IOrganizationService
             }).ToList();
     }
 
-    public async Task<List<DepartmentRepositoryInfo>> GetDepartmentRepositoriesAsync(string userId)
+    public async Task<List<DepartmentRepositoryInfo>> GetDepartmentRepositoriesAsync(string userId, bool includeRestricted = false)
     {
         // 获取用户所属的部门
         var userDeptIds = await _context.UserDepartments
@@ -53,10 +54,14 @@ public class OrganizationService : IOrganizationService
             .Where(d => userDeptIds.Contains(d.Id) && d.IsActive)
             .ToDictionaryAsync(d => d.Id);
 
-        // 获取这些部门分配的仓库
-        var assignments = await _context.RepositoryAssignments
-            .Where(ra => userDeptIds.Contains(ra.DepartmentId) && !ra.IsDeleted)
-            .ToListAsync();
+        // Get repositories assigned to these departments
+        var assignmentsQuery = _context.RepositoryAssignments
+            .Where(ra => userDeptIds.Contains(ra.DepartmentId));
+
+        if (!includeRestricted)
+            assignmentsQuery = assignmentsQuery.Where(ra => !ra.IsDeleted);
+
+        var assignments = await assignmentsQuery.ToListAsync();
 
         var repoIds = assignments.Select(a => a.RepositoryId).Distinct().ToList();
         var repos = await _context.Repositories
@@ -74,10 +79,140 @@ public class OrganizationService : IOrganizationService
                 Status = (int)repos[a.RepositoryId].Status,
                 StatusName = GetStatusName((int)repos[a.RepositoryId].Status),
                 DepartmentId = a.DepartmentId,
-                DepartmentName = depts[a.DepartmentId].Name
+                DepartmentName = depts[a.DepartmentId].Name,
+                CreatedAt = repos[a.RepositoryId].CreatedAt,
+                PrimaryLanguage = repos[a.RepositoryId].PrimaryLanguage,
+                IsRestricted = a.IsDeleted,
+                IsPublic = repos[a.RepositoryId].IsPublic
             })
             .DistinctBy(r => r.RepositoryId)
             .ToList();
+    }
+
+    public async Task<bool> ShareRepositoryWithMyDepartmentsAsync(string userId, string repositoryId)
+    {
+        var repo = await _context.Repositories.FirstOrDefaultAsync(r => r.Id == repositoryId && !r.IsDeleted);
+        if (repo == null || repo.OwnerUserId != userId) return false;
+
+        var userDeptIds = await _context.UserDepartments
+            .Where(ud => ud.UserId == userId && !ud.IsDeleted)
+            .Select(ud => ud.DepartmentId)
+            .ToListAsync();
+
+        if (userDeptIds.Count == 0) return false;
+
+        // Get ALL existing assignments (including soft-deleted)
+        var existingAssignments = await _context.RepositoryAssignments
+            .Where(ra => ra.RepositoryId == repositoryId && userDeptIds.Contains(ra.DepartmentId))
+            .ToListAsync();
+
+        foreach (var deptId in userDeptIds)
+        {
+            var existing = existingAssignments.FirstOrDefault(a => a.DepartmentId == deptId);
+            if (existing != null)
+            {
+                // Un-soft-delete if it was restricted
+                if (existing.IsDeleted)
+                {
+                    existing.IsDeleted = false;
+                    existing.DeletedAt = null;
+                }
+            }
+            else
+            {
+                _context.RepositoryAssignments.Add(new RepositoryAssignment
+                {
+                    Id = Guid.NewGuid().ToString("N"),
+                    RepositoryId = repositoryId,
+                    DepartmentId = deptId,
+                    AssigneeUserId = userId
+                });
+            }
+        }
+
+        await _context.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<bool> UnshareRepositoryFromMyDepartmentsAsync(string userId, string repositoryId)
+    {
+        // 1. Verify user owns the repository
+        var repo = await _context.Repositories.FirstOrDefaultAsync(r => r.Id == repositoryId && !r.IsDeleted);
+        if (repo == null || repo.OwnerUserId != userId) return false;
+
+        // 2. Get user's departments
+        var userDeptIds = await _context.UserDepartments
+            .Where(ud => ud.UserId == userId && !ud.IsDeleted)
+            .Select(ud => ud.DepartmentId)
+            .ToListAsync();
+
+        // 3. Soft-delete assignments for user's departments
+        var assignments = await _context.RepositoryAssignments
+            .Where(ra => ra.RepositoryId == repositoryId && userDeptIds.Contains(ra.DepartmentId) && !ra.IsDeleted)
+            .ToListAsync();
+
+        foreach (var assignment in assignments)
+        {
+            assignment.IsDeleted = true;
+            assignment.DeletedAt = DateTime.UtcNow;
+        }
+
+        await _context.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<bool> RestrictRepositoryInDepartmentsAsync(string repositoryId, string adminUserId)
+    {
+        // Get admin's departments
+        var adminDeptIds = await _context.UserDepartments
+            .Where(ud => ud.UserId == adminUserId && !ud.IsDeleted)
+            .Select(ud => ud.DepartmentId)
+            .ToListAsync();
+
+        if (adminDeptIds.Count == 0) return false;
+
+        // Soft-delete active assignments for these departments
+        var assignments = await _context.RepositoryAssignments
+            .Where(ra => ra.RepositoryId == repositoryId && adminDeptIds.Contains(ra.DepartmentId) && !ra.IsDeleted)
+            .ToListAsync();
+
+        if (assignments.Count == 0) return false;
+
+        foreach (var assignment in assignments)
+        {
+            assignment.IsDeleted = true;
+            assignment.DeletedAt = DateTime.UtcNow;
+        }
+
+        await _context.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<bool> UnrestrictRepositoryInDepartmentsAsync(string repositoryId, string adminUserId)
+    {
+        // Get admin's departments
+        var adminDeptIds = await _context.UserDepartments
+            .Where(ud => ud.UserId == adminUserId && !ud.IsDeleted)
+            .Select(ud => ud.DepartmentId)
+            .ToListAsync();
+
+        if (adminDeptIds.Count == 0) return false;
+
+        // Un-soft-delete restricted assignments for these departments
+        var assignments = await _context.RepositoryAssignments
+            .Where(ra => ra.RepositoryId == repositoryId && adminDeptIds.Contains(ra.DepartmentId) && ra.IsDeleted)
+            .ToListAsync();
+
+        if (assignments.Count == 0) return false;
+
+        foreach (var assignment in assignments)
+        {
+            assignment.IsDeleted = false;
+            assignment.DeletedAt = null;
+        }
+
+        await _context.SaveChangesAsync();
+        return true;
     }
 
     private static string GetStatusName(int status) => status switch

--- a/src/OpenDeepWiki/Services/Repositories/RepositoryService.cs
+++ b/src/OpenDeepWiki/Services/Repositories/RepositoryService.cs
@@ -4,12 +4,13 @@ using OpenDeepWiki.EFCore;
 using OpenDeepWiki.Entities;
 using OpenDeepWiki.Models;
 using OpenDeepWiki.Services.Auth;
+using OpenDeepWiki.Services.GitHub;
 
 namespace OpenDeepWiki.Services.Repositories;
 
 [MiniApi(Route = "/api/v1/repositories")]
-[Tags("仓库")]
-public class RepositoryService(IContext context, IGitPlatformService gitPlatformService, IUserContext userContext)
+[Tags("Repository")]
+public class RepositoryService(IContext context, IGitPlatformService gitPlatformService, IUserContext userContext, IGitHubAppService gitHubAppService)
 {
     [HttpPost("/submit")]
     public async Task<Repository> SubmitAsync([FromBody] RepositorySubmitRequest request)

--- a/web/app/(main)/page.tsx
+++ b/web/app/(main)/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useCallback, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { AppLayout } from "@/components/app-layout";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -16,13 +16,21 @@ import {
 import { useAuth } from "@/contexts/auth-context";
 import { useScrollPosition } from "@/hooks/use-scroll-position";
 import { PublicRepositoryList } from "@/components/repo/public-repository-list";
+import type { RepositoryView } from "@/components/repo/public-repository-list";
 import { cn } from "@/lib/utils";
 
-export default function Home() {
+function HomeContent() {
   const t = useTranslations();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { user } = useAuth();
-  const [activeItem, setActiveItem] = useState(t("sidebar.explore"));
+
+  const viewParam = (searchParams.get("view") as RepositoryView) || "public";
+
+  const activeItem = (viewParam === "organization" || viewParam === "mine")
+    ? t("sidebar.private")
+    : t("sidebar.explore");
+
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isIntegrationsOpen, setIsIntegrationsOpen] = useState(false);
   const [keyword, setKeyword] = useState("");
@@ -40,10 +48,21 @@ export default function Home() {
     setIsFormOpen(true);
   }, [user, router]);
 
+  const handleViewChange = useCallback((newView: RepositoryView) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (newView === "public") {
+      params.delete("view");
+    } else {
+      params.set("view", newView);
+    }
+    const query = params.toString();
+    router.replace(query ? `/?${query}` : "/", { scroll: false });
+  }, [router, searchParams]);
+
   return (
     <AppLayout
       activeItem={activeItem}
-      onItemClick={setActiveItem}
+      onItemClick={() => {}}
       searchBox={{
         value: keyword,
         onChange: setKeyword,
@@ -118,11 +137,23 @@ export default function Home() {
           </div>
         </div>
 
-        {/* Public Repository List Section */}
+        {/* Repository List Section */}
         <div className="w-full max-w-6xl mx-auto mt-8">
-          <PublicRepositoryList keyword={keyword} />
+          <PublicRepositoryList
+            keyword={keyword}
+            view={viewParam}
+            onViewChange={handleViewChange}
+          />
         </div>
       </div>
     </AppLayout>
+  );
+}
+
+export default function Home() {
+  return (
+    <Suspense fallback={null}>
+      <HomeContent />
+    </Suspense>
   );
 }

--- a/web/app/(main)/private/github-import/page.tsx
+++ b/web/app/(main)/private/github-import/page.tsx
@@ -85,7 +85,7 @@ export default function UserGitHubImportPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <Link href="/private">
+            <Link href="/?view=organization">
               <Button variant="ghost" size="sm">
                 <ArrowLeft className="h-4 w-4 mr-2" />
                 {t("home.githubImport.backToPrivate")}

--- a/web/app/(main)/private/page.tsx
+++ b/web/app/(main)/private/page.tsx
@@ -1,78 +1,12 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { AppLayout } from "@/components/app-layout";
-import { useTranslations } from "@/hooks/use-translations";
-import { Button } from "@/components/ui/button";
-import { Plus } from "lucide-react";
-import { RepositorySubmitForm } from "@/components/repo/repository-submit-form";
-import { RepositoryList } from "@/components/repo/repository-list";
-import {
-  Sheet,
-  SheetContent,
-  SheetTrigger,
-} from "@/components/animate-ui/components/radix/sheet";
-import { useAuth } from "@/contexts/auth-context";
-import Link from "next/link";
-
-const GithubIcon = ({ className }: { className?: string }) => (
-  <svg className={className} viewBox="0 0 24 24" fill="currentColor" width="16" height="16">
-    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-  </svg>
-);
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 export default function PrivatePage() {
-  const t = useTranslations();
-  const { user } = useAuth();
-  const [activeItem, setActiveItem] = useState(t("sidebar.private"));
-  const [isFormOpen, setIsFormOpen] = useState(false);
-  const [refreshTrigger, setRefreshTrigger] = useState(0);
-
-  const handleSubmitSuccess = useCallback(() => {
-    setIsFormOpen(false);
-    setRefreshTrigger((prev) => prev + 1);
-  }, []);
-
-  // Use a placeholder user ID if not authenticated
-  const ownerUserId = user?.id ?? "anonymous";
-
-  return (
-    <AppLayout activeItem={activeItem} onItemClick={setActiveItem}>
-      <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
-        <div className="flex items-center justify-between">
-          <div className="space-y-2">
-            <h1 className="text-3xl font-bold tracking-tight">{t("sidebar.private")}</h1>
-            <p className="text-muted-foreground">
-              {t("common.privateRepos.description")}
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Link href="/private/github-import">
-              <Button variant="outline" className="gap-2">
-                <GithubIcon className="h-4 w-4" />
-                {t("home.importFromGitHub")}
-              </Button>
-            </Link>
-            <Sheet open={isFormOpen} onOpenChange={setIsFormOpen}>
-              <SheetTrigger asChild>
-                <Button className="gap-2">
-                  <Plus className="h-4 w-4" />
-                  {t("home.addPrivateRepo")}
-                </Button>
-              </SheetTrigger>
-            <SheetContent side="right" className="w-full sm:max-w-lg overflow-y-auto">
-              <div className="pt-6">
-                <RepositorySubmitForm
-                  onSuccess={handleSubmitSuccess}
-                />
-              </div>
-            </SheetContent>
-            </Sheet>
-          </div>
-        </div>
-
-        <RepositoryList ownerId={ownerUserId} refreshTrigger={refreshTrigger} />
-      </div>
-    </AppLayout>
-  );
+  const router = useRouter();
+  useEffect(() => {
+    router.replace("/?view=mine");
+  }, [router]);
+  return null;
 }

--- a/web/app/sidebar.tsx
+++ b/web/app/sidebar.tsx
@@ -8,7 +8,7 @@ import {
     Bookmark,
     Building2,
     AppWindow,
-    Zap,
+    Lock,
 } from "lucide-react";
 import {
     Sidebar,
@@ -52,7 +52,7 @@ const GithubIcon = ({ className }: { className?: string }) => (
 const itemKeys = [
     { key: "explore", url: "/", icon: Compass, requireAuth: false },
     { key: "recommend", url: "/recommend", icon: ThumbsUp, requireAuth: false },
-    { key: "private", url: "/private", icon: GitFork, requireAuth: true },
+    { key: "private", url: "/?view=organization", icon: Lock, requireAuth: true },
     { key: "subscribe", url: "/subscribe", icon: Star, requireAuth: true },
     { key: "bookmarks", url: "/bookmarks", icon: Bookmark, requireAuth: true },
     { key: "organizations", url: "/organizations", icon: Building2, requireAuth: false },

--- a/web/components/repo/language-tags.tsx
+++ b/web/components/repo/language-tags.tsx
@@ -11,6 +11,7 @@ interface LanguageTagsProps {
   selectedLanguage: string | null;
   onLanguageChange: (language: string | null) => void;
   className?: string;
+  languages?: LanguageInfo[];
 }
 
 // 语言颜色映射
@@ -35,15 +36,20 @@ const languageColors: Record<string, string> = {
 
 const defaultColor = "bg-muted hover:bg-muted/80 text-muted-foreground border-border";
 
-export function LanguageTags({ selectedLanguage, onLanguageChange, className }: LanguageTagsProps) {
-  const [languages, setLanguages] = useState<LanguageInfo[]>([]);
+export function LanguageTags({ selectedLanguage, onLanguageChange, className, languages: languagesProp }: LanguageTagsProps) {
+  const [languageData, setLanguageData] = useState<LanguageInfo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    if (languagesProp) {
+      setLanguageData(languagesProp);
+      setIsLoading(false);
+      return;
+    }
     const loadLanguages = async () => {
       try {
         const response = await getAvailableLanguages();
-        setLanguages(response.languages);
+        setLanguageData(response.languages);
       } catch (error) {
         console.error("Failed to load languages:", error);
       } finally {
@@ -51,7 +57,7 @@ export function LanguageTags({ selectedLanguage, onLanguageChange, className }: 
       }
     };
     loadLanguages();
-  }, []);
+  }, [languagesProp]);
 
   if (isLoading) {
     return (
@@ -63,7 +69,7 @@ export function LanguageTags({ selectedLanguage, onLanguageChange, className }: 
     );
   }
 
-  if (languages.length === 0) {
+  if (languageData.length === 0) {
     return null;
   }
 
@@ -82,7 +88,7 @@ export function LanguageTags({ selectedLanguage, onLanguageChange, className }: 
       >
         全部
       </Badge>
-      {languages.map((lang) => (
+      {languageData.map((lang) => (
         <Badge
           key={lang.name}
           variant="outline"

--- a/web/components/repo/public-repository-card.tsx
+++ b/web/components/repo/public-repository-card.tsx
@@ -12,16 +12,21 @@ import {
   Loader2,
   CheckCircle2,
   XCircle,
-  GitBranch,
+  Globe,
+  Building2,
   Calendar,
   Bookmark,
   Bell,
   Star,
   GitFork,
+  Lock,
+  EyeOff,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { addBookmark, removeBookmark, getBookmarkStatus } from "@/lib/bookmark-api";
 import { addSubscription, removeSubscription, getSubscriptionStatus } from "@/lib/subscription-api";
+import { shareRepoWithOrganization, unshareRepoFromOrganization, restrictRepoInOrganization, unrestrictRepoInOrganization } from "@/lib/organization-api";
+import { Switch } from "@/components/ui/switch";
 import { toast } from "sonner";
 
 const STATUS_CONFIG: Record<RepositoryStatus, {
@@ -74,17 +79,22 @@ function StatusBadge({ status }: { status: RepositoryStatus }) {
 
 interface PublicRepositoryCardProps {
   repository: RepositoryItemResponse;
+  onShareToggle?: (repositoryId: string, shared: boolean) => void;
+  toggleMode?: "share" | "restrict";
 }
 
-export function PublicRepositoryCard({ repository }: PublicRepositoryCardProps) {
+export function PublicRepositoryCard({ repository, onShareToggle, toggleMode = "share" }: PublicRepositoryCardProps) {
   const t = useTranslations();
   const { user } = useAuth();
-  const createdDate = new Date(repository.createdAt).toLocaleDateString();
+  const createdDate = repository.createdAt
+    ? new Date(repository.createdAt).toLocaleDateString()
+    : null;
 
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [isSubscribed, setIsSubscribed] = useState(false);
   const [bookmarkLoading, setBookmarkLoading] = useState(false);
   const [subscribeLoading, setSubscribeLoading] = useState(false);
+  const [shareLoading, setShareLoading] = useState(false);
 
   // 获取收藏和订阅状态
   useEffect(() => {
@@ -152,14 +162,66 @@ export function PublicRepositoryCard({ repository }: PublicRepositoryCardProps) 
     }
   }, [user, repository.id, isSubscribed, subscribeLoading, t]);
 
+  const handleShareToggle = useCallback(async (checked: boolean) => {
+    if (shareLoading) return;
+    setShareLoading(true);
+    try {
+      if (toggleMode === "restrict") {
+        // Admin restrict/unrestrict in org view
+        if (checked) {
+          // Toggle ON = visible = unrestrict
+          await unrestrictRepoInOrganization(repository.id);
+          toast.success(t("home.filter.visibleToOrg"));
+        } else {
+          // Toggle OFF = restricted
+          await restrictRepoInOrganization(repository.id);
+          toast.success(t("home.filter.restricted"));
+        }
+      } else {
+        // User share/unshare in mine view
+        if (checked) {
+          await shareRepoWithOrganization(repository.id);
+          toast.success(t("home.filter.sharedWithOrg"));
+        } else {
+          await unshareRepoFromOrganization(repository.id);
+          toast.success(t("home.filter.unsharedFromOrg"));
+        }
+      }
+      onShareToggle?.(repository.id, checked);
+    } catch {
+      toast.error(t("home.actions.actionError"));
+    } finally {
+      setShareLoading(false);
+    }
+  }, [repository.id, shareLoading, onShareToggle, toggleMode, t]);
+
   return (
     <Link href={`/${repository.orgName}/${repository.repoName}`}>
-      <Card className="h-full transition-all hover:shadow-md hover:border-primary/50 cursor-pointer">
+      <Card className={cn(
+        "h-full transition-all hover:shadow-md hover:border-primary/50 cursor-pointer",
+        repository.isRestricted && "opacity-60"
+      )}>
         <CardContent className="p-4">
           <div className="flex flex-col gap-3">
             <div className="flex items-center justify-between gap-2">
               <div className="flex items-center gap-2 min-w-0">
-                <GitBranch className="h-4 w-4 text-muted-foreground shrink-0" />
+                {/* Icons: dual display for repos that are both public AND in a department.
+                    Restricted repos show EyeOff regardless. Private-only shows Lock. */}
+                {repository.isRestricted ? (
+                  <span title={t("home.icons.restricted")}><EyeOff className="h-4 w-4 text-gray-400 shrink-0" /></span>
+                ) : (
+                  <div className="flex items-center gap-0.5 shrink-0">
+                    {repository.isPublic && (
+                      <span title={t("home.icons.public")}><Globe className="h-4 w-4 text-green-500" /></span>
+                    )}
+                    {repository.departmentName && (
+                      <span title={t("home.icons.organization")}><Building2 className="h-4 w-4 text-blue-500" /></span>
+                    )}
+                    {!repository.isPublic && !repository.departmentName && (
+                      <span title={t("home.icons.private")}><Lock className="h-4 w-4 text-amber-500" /></span>
+                    )}
+                  </div>
+                )}
                 <h3 className="font-medium truncate">
                   {repository.orgName}/{repository.repoName}
                 </h3>
@@ -168,10 +230,12 @@ export function PublicRepositoryCard({ repository }: PublicRepositoryCardProps) 
             </div>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3 text-xs text-muted-foreground">
-                <div className="flex items-center gap-1">
-                  <Calendar className="h-3.5 w-3.5" />
-                  <span>{createdDate}</span>
-                </div>
+                {createdDate && createdDate !== "Invalid Date" && (
+                  <div className="flex items-center gap-1">
+                    <Calendar className="h-3.5 w-3.5" />
+                    <span>{createdDate}</span>
+                  </div>
+                )}
                 {typeof repository.starCount === "number" && (
                   <div className="flex items-center gap-1">
                     <Star className="h-3.5 w-3.5" />
@@ -226,6 +290,25 @@ export function PublicRepositoryCard({ repository }: PublicRepositoryCardProps) 
               )}
             </div>
           </div>
+          {onShareToggle && (
+            <div className="flex items-center gap-2 pt-2 border-t mt-2" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
+              {shareLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Building2 className="h-4 w-4 text-muted-foreground" />
+              )}
+              <Switch
+                checked={toggleMode === "restrict" ? !repository.isRestricted : !!repository.departmentName}
+                onCheckedChange={handleShareToggle}
+                disabled={shareLoading}
+              />
+              <span className="text-sm text-muted-foreground">
+                {toggleMode === "restrict"
+                  ? (repository.isRestricted ? t("home.filter.restricted") : t("home.filter.visibleToOrg"))
+                  : (repository.departmentName ? t("home.filter.sharedWithOrg") : t("home.filter.shareWithOrg"))}
+              </span>
+            </div>
+          )}
         </CardContent>
       </Card>
     </Link>

--- a/web/components/repo/public-repository-list.tsx
+++ b/web/components/repo/public-repository-list.tsx
@@ -1,22 +1,87 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { useTranslations } from "@/hooks/use-translations";
 import { fetchRepositoryList } from "@/lib/repository-api";
+import { getMyDepartmentRepositories, restrictRepoInOrganization, unrestrictRepoInOrganization } from "@/lib/organization-api";
+import type { DepartmentRepository } from "@/lib/organization-api";
 import { PublicRepositoryCard } from "./public-repository-card";
 import { LanguageTags } from "./language-tags";
 import type { RepositoryItemResponse } from "@/types/repository";
-import { GitBranch, XCircle, RefreshCw, Search, ChevronLeft, ChevronRight } from "lucide-react";
+import type { LanguageInfo } from "@/lib/recommendation-api";
+import { GitBranch, XCircle, RefreshCw, Search, ChevronLeft, ChevronRight, Globe, Building2, User, Layers, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useAuth } from "@/contexts/auth-context";
+import Link from "next/link";
+import { RepositorySubmitForm } from "@/components/repo/repository-submit-form";
+import {
+  Dialog,
+  DialogContent,
+} from "@/components/ui/dialog";
+
+/**
+ * ADR: Unified Dashboard Repository Views
+ *
+ * Data Sources:
+ * - Public repos: server-side paginated via fetchRepositoryList({ isPublic: true })
+ * - Org (department) repos: client-side via getMyDepartmentRepositories()
+ * - User-owned repos: server-side via fetchRepositoryList({ ownerId: user.id })
+ *
+ * Key Design Decisions:
+ *
+ * 1. DUAL DATA MODEL: Public API returns RepositoryItemResponse (no departmentName),
+ *    while org API returns DepartmentRepository (no star/fork counts). We enrich
+ *    public repos with departmentName from dept data for dual-icon display.
+ *
+ * 2. OWNERSHIP vs DEPARTMENT: GitHub App imports set OwnerUserId to the importing
+ *    admin, making all org repos appear as "owned". The Mine view therefore
+ *    subtracts dept repos by default to show only truly personal repos.
+ *
+ * 3. SUB-FILTERS: Each view has contextual sub-filters applied client-side:
+ *    - Public: "publicOnly" fetches all + dept IDs, excludes overlap
+ *    - Organization: "privateOnly" filters mapped dept repos by !isPublic
+ *    - Mine: default excludes dept repos; "shared"/"all" include them
+ *
+ * 4. RACE CONDITION PROTECTION: loadIdRef counter ensures only the latest
+ *    async request's results are applied. Stale responses are silently discarded.
+ *
+ * 5. STALE STATE CLEARING: effectiveView change clears repositories, languages,
+ *    total, page, and subFilter to prevent flash of previous view's data.
+ *
+ * 6. PAGINATION: Public (default) uses server-side pagination (PAGE_SIZE=12).
+ *    All other views and sub-filtered public use client-side pagination
+ *    (fetch MAX_CLIENT_PAGE_SIZE=200, slice locally).
+ */
+
+export type RepositoryView = "all" | "public" | "organization" | "mine";
 
 interface PublicRepositoryListProps {
   keyword: string;
+  view?: RepositoryView;
+  onViewChange?: (view: RepositoryView) => void;
   className?: string;
 }
 
 const PAGE_SIZE = 12;
+const MAX_CLIENT_PAGE_SIZE = 200;
+
+function mapDepartmentRepoToItem(repo: DepartmentRepository): RepositoryItemResponse {
+  return {
+    id: repo.repositoryId,
+    orgName: repo.orgName,
+    repoName: repo.repoName,
+    gitUrl: repo.gitUrl || "",
+    status: repo.status,
+    statusName: (repo.statusName as RepositoryItemResponse["statusName"]) || "Pending",
+    isPublic: repo.isPublic ?? false,
+    createdAt: repo.createdAt || "",
+    departmentName: repo.departmentName,
+    primaryLanguage: repo.primaryLanguage,
+    isRestricted: repo.isRestricted || false,
+  };
+}
 
 function RepositoryGridSkeleton() {
   return (
@@ -36,47 +101,290 @@ function RepositoryGridSkeleton() {
   );
 }
 
-export function PublicRepositoryList({ keyword, className }: PublicRepositoryListProps) {
+function computeLanguageStats(repos: RepositoryItemResponse[]): LanguageInfo[] {
+  const counts = new Map<string, number>();
+  for (const r of repos) {
+    if (r.primaryLanguage) {
+      counts.set(r.primaryLanguage, (counts.get(r.primaryLanguage) || 0) + 1);
+    }
+  }
+  return Array.from(counts.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+const GithubIcon = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="currentColor" width="16" height="16">
+    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+  </svg>
+);
+
+export function PublicRepositoryList({ keyword, view = "public", onViewChange, className }: PublicRepositoryListProps) {
   const t = useTranslations();
+  const { user } = useAuth();
+  const isAdmin = user?.roles?.includes("Admin") ?? false;
   const [repositories, setRepositories] = useState<RepositoryItemResponse[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedLanguage, setSelectedLanguage] = useState<string | null>(null);
   const [page, setPage] = useState(1);
   const [total, setTotal] = useState(0);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [viewLanguages, setViewLanguages] = useState<LanguageInfo[] | null>(null);
+  const [subFilter, setSubFilter] = useState<string | null>(null);
+
+  // Effective view: fall back to "public" if auth-required view is used without auth
+  const effectiveView = useMemo(() => {
+    if ((view === "organization" || view === "mine") && !user) {
+      return "public";
+    }
+    return view;
+  }, [view, user]);
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
+  // Race condition protection: only the latest request's results are applied
+  const loadIdRef = useRef(0);
+
   const loadRepositories = useCallback(async () => {
+    const loadId = ++loadIdRef.current;
     try {
       setIsLoading(true);
       setError(null);
-      const response = await fetchRepositoryList({
-        isPublic: true,
-        sortBy: "status",
-        keyword: keyword || undefined,
-        language: selectedLanguage || undefined,
-        page,
-        pageSize: PAGE_SIZE,
-      });
-      setRepositories(response.items);
-      setTotal(response.total);
+
+      switch (effectiveView) {
+        case "public": {
+          // Fetch public repos + dept repos (for enrichment & sub-filter)
+          const pubDeptRepos = user
+            ? await getMyDepartmentRepositories().catch(() => [] as DepartmentRepository[])
+            : [];
+          if (loadId !== loadIdRef.current) return;
+
+          // Build dept lookup for enrichment
+          const pubDeptMap = new Map(pubDeptRepos.map(r => [r.repositoryId, r.departmentName]));
+
+          // Helper: enrich public repos with departmentName from dept data
+          const enrichPublicRepos = (items: RepositoryItemResponse[]) =>
+            items.map(r => pubDeptMap.has(r.id) ? { ...r, departmentName: pubDeptMap.get(r.id) } : r);
+
+          if (subFilter === "publicOnly" && user) {
+            // Client-side: fetch all public, exclude org repos
+            const pubAllResponse = await fetchRepositoryList({
+              isPublic: true,
+              sortBy: "status",
+              keyword: keyword || undefined,
+              pageSize: MAX_CLIENT_PAGE_SIZE,
+            });
+            if (loadId !== loadIdRef.current) return;
+            let filtered = pubAllResponse.items.filter(r => !pubDeptMap.has(r.id));
+            setViewLanguages(computeLanguageStats(filtered));
+            if (selectedLanguage) {
+              filtered = filtered.filter(r => r.primaryLanguage?.toLowerCase() === selectedLanguage.toLowerCase());
+            }
+            setTotal(filtered.length);
+            const pubStart = (page - 1) * PAGE_SIZE;
+            setRepositories(filtered.slice(pubStart, pubStart + PAGE_SIZE));
+          } else {
+            // Default: server-side paginated, enrich with dept info
+            setViewLanguages(null);
+            const response = await fetchRepositoryList({
+              isPublic: true,
+              sortBy: "status",
+              keyword: keyword || undefined,
+              language: selectedLanguage || undefined,
+              page,
+              pageSize: PAGE_SIZE,
+            });
+            if (loadId !== loadIdRef.current) return;
+            setRepositories(enrichPublicRepos(response.items));
+            setTotal(response.total);
+          }
+          break;
+        }
+
+        case "mine": {
+          if (!user) break;
+          const [mineResponse, mineDeptRepos] = await Promise.all([
+            fetchRepositoryList({
+              ownerId: user.id,
+              sortBy: "status",
+              keyword: keyword || undefined,
+              pageSize: MAX_CLIENT_PAGE_SIZE,
+            }),
+            getMyDepartmentRepositories().catch(() => [] as DepartmentRepository[]),
+          ]);
+
+          if (loadId !== loadIdRef.current) return;
+
+          // Base: all owned private repos (exclude public since user didn't create those)
+          const mineDeptRepoIds = new Set(mineDeptRepos.map(r => r.repositoryId));
+          let myRepos = mineResponse.items.filter(r => !r.isPublic);
+
+          // Sub-filter: default excludes dept repos (org-imported repos belong to org, not user)
+          if (subFilter === "shared") {
+            myRepos = myRepos.filter(r => mineDeptRepoIds.has(r.id));
+          } else if (subFilter !== "all") {
+            // Default (null) and "notShared": exclude dept repos = truly personal only
+            myRepos = myRepos.filter(r => !mineDeptRepoIds.has(r.id));
+          }
+
+          setViewLanguages(computeLanguageStats(myRepos));
+          if (selectedLanguage) {
+            myRepos = myRepos.filter(r => r.primaryLanguage === selectedLanguage);
+          }
+          const mineTotal = myRepos.length;
+          const mineStart = (page - 1) * PAGE_SIZE;
+          setTotal(mineTotal);
+          setRepositories(myRepos.slice(mineStart, mineStart + PAGE_SIZE));
+          break;
+        }
+
+        case "organization": {
+          if (!user) break;
+          const orgDeptRepos = await getMyDepartmentRepositories(isAdmin);
+          if (loadId !== loadIdRef.current) return;
+          let mapped = orgDeptRepos.map(mapDepartmentRepoToItem);
+
+          setViewLanguages(computeLanguageStats(mapped));
+
+          // Client-side keyword filter
+          if (keyword) {
+            const kw = keyword.toLowerCase();
+            mapped = mapped.filter(
+              (r) =>
+                r.orgName.toLowerCase().includes(kw) ||
+                r.repoName.toLowerCase().includes(kw)
+            );
+          }
+          // Sub-filter: private only
+          if (subFilter === "privateOnly") {
+            mapped = mapped.filter((r) => !r.isPublic);
+          }
+          // Client-side language filter
+          if (selectedLanguage) {
+            mapped = mapped.filter(
+              (r) => r.primaryLanguage?.toLowerCase() === selectedLanguage.toLowerCase()
+            );
+          }
+
+          setTotal(mapped.length);
+          // Client-side pagination
+          const start = (page - 1) * PAGE_SIZE;
+          setRepositories(mapped.slice(start, start + PAGE_SIZE));
+          break;
+        }
+
+        case "all": {
+          // For unauthenticated users, same as public
+          if (!user) {
+            setViewLanguages(null);
+            const response = await fetchRepositoryList({
+              isPublic: true,
+              sortBy: "status",
+              keyword: keyword || undefined,
+              language: selectedLanguage || undefined,
+              page,
+              pageSize: PAGE_SIZE,
+            });
+            if (loadId !== loadIdRef.current) return;
+            setRepositories(response.items);
+            setTotal(response.total);
+            break;
+          }
+
+          // Fetch all sources in parallel
+          const [allPublicResponse, allDeptRepos, allOwnResponse] = await Promise.all([
+            fetchRepositoryList({
+              isPublic: true,
+              sortBy: "status",
+              keyword: keyword || undefined,
+              pageSize: MAX_CLIENT_PAGE_SIZE,
+            }),
+            getMyDepartmentRepositories(isAdmin).catch(() => [] as DepartmentRepository[]),
+            fetchRepositoryList({
+              ownerId: user.id,
+              sortBy: "status",
+              keyword: keyword || undefined,
+              pageSize: MAX_CLIENT_PAGE_SIZE,
+            }).catch(() => ({ items: [] as RepositoryItemResponse[], total: 0 })),
+          ]);
+
+          if (loadId !== loadIdRef.current) return;
+
+          // Merge: start with owned repos, then OVERWRITE with dept repos (they have departmentName), then add remaining public
+          const repoMap = new Map<string, RepositoryItemResponse>();
+          // First: owned repos (these may lack departmentName)
+          if (user) {
+            for (const r of allOwnResponse.items) repoMap.set(r.id, r);
+          }
+          // Second: dept repos OVERWRITE owned versions (to get correct departmentName + icon)
+          for (const dr of allDeptRepos) {
+            repoMap.set(dr.repositoryId, mapDepartmentRepoToItem(dr));
+          }
+          // Third: public repos (don't overwrite)
+          for (const r of allPublicResponse.items) {
+            if (!repoMap.has(r.id)) repoMap.set(r.id, r);
+          }
+
+          const allRepos = Array.from(repoMap.values());
+          setViewLanguages(computeLanguageStats(allRepos));
+
+          // Client-side language filter
+          let filteredRepos = allRepos;
+          if (selectedLanguage) {
+            filteredRepos = allRepos.filter(
+              (r) => r.primaryLanguage?.toLowerCase() === selectedLanguage.toLowerCase()
+            );
+          }
+          setTotal(filteredRepos.length);
+          // Client-side pagination
+          const allStart = (page - 1) * PAGE_SIZE;
+          setRepositories(filteredRepos.slice(allStart, allStart + PAGE_SIZE));
+          break;
+        }
+      }
     } catch (err) {
+      if (loadId !== loadIdRef.current) return;
       setError("Failed to load repositories");
-      console.error("Failed to fetch public repositories:", err);
+      console.error("Failed to fetch repositories:", err);
     } finally {
-      setIsLoading(false);
+      if (loadId === loadIdRef.current) {
+        setIsLoading(false);
+      }
     }
-  }, [keyword, selectedLanguage, page]);
+  }, [effectiveView, keyword, selectedLanguage, page, user, subFilter]);
 
   useEffect(() => {
     loadRepositories();
   }, [loadRepositories]);
 
-  // 当筛选条件变化时重置页码
+  // Clear stale state when view changes (prevents flash of old data)
+  useEffect(() => {
+    setRepositories([]);
+    setViewLanguages(null);
+    setTotal(0);
+    setPage(1);
+    setSubFilter(null);
+  }, [effectiveView]);
+
+  // Reset page when keyword/language/sub filter changes (within same view)
   useEffect(() => {
     setPage(1);
-  }, [keyword, selectedLanguage]);
+  }, [keyword, selectedLanguage, subFilter]);
+
+  // Auto-refresh for pending/processing repositories (ported from repository-list.tsx)
+  useEffect(() => {
+    if (effectiveView === "public") return; // Public repos don't need auto-refresh
+
+    const hasPendingOrProcessing = repositories.some(
+      (r) => r.statusName === "Pending" || r.statusName === "Processing"
+    );
+
+    if (hasPendingOrProcessing) {
+      const interval = setInterval(loadRepositories, 10000);
+      return () => clearInterval(interval);
+    }
+  }, [repositories, loadRepositories, effectiveView]);
 
   const handleLanguageChange = (language: string | null) => {
     setSelectedLanguage(language);
@@ -90,12 +398,109 @@ export function PublicRepositoryList({ keyword, className }: PublicRepositoryLis
     if (page < totalPages) setPage(page + 1);
   };
 
+  const handleViewChange = (newView: RepositoryView) => {
+    onViewChange?.(newView);
+  };
+
+  const handleSubmitSuccess = useCallback(() => {
+    setIsFormOpen(false);
+    loadRepositories();
+  }, [loadRepositories]);
+
+  // Dynamic section title
+  const sectionTitle = useMemo(() => {
+    switch (effectiveView) {
+      case "all":
+        return t("home.filter.allTitle");
+      case "public":
+        return t("home.publicRepository.title");
+      case "organization":
+        return t("home.filter.organizationTitle");
+      case "mine":
+        return t("home.repository.listTitle");
+    }
+  }, [effectiveView, t]);
+
+  // Dynamic empty state message
+  const emptyMessage = useMemo(() => {
+    switch (effectiveView) {
+      case "organization":
+        return t("home.filter.organizationEmpty");
+      case "mine":
+        return t("home.filter.myReposEmpty");
+      default:
+        return t("home.publicRepository.empty");
+    }
+  }, [effectiveView, t]);
+
+  // Filter tabs
+  const filterTabs: { key: RepositoryView; label: string; icon: React.ElementType; requireAuth: boolean }[] = [
+    { key: "all", label: t("home.filter.all"), icon: Layers, requireAuth: false },
+    { key: "public", label: t("home.filter.public"), icon: Globe, requireAuth: false },
+    { key: "organization", label: t("home.filter.organization"), icon: Building2, requireAuth: true },
+    { key: "mine", label: t("home.filter.myRepos"), icon: User, requireAuth: true },
+  ];
+
+  const visibleTabs = filterTabs.filter((tab) => !tab.requireAuth || user);
+
+  const subFilterOptions = useMemo(() => {
+    switch (effectiveView) {
+      case "public":
+        return user ? [
+          { key: null, label: t("home.filter.subAll") },
+          { key: "publicOnly", label: t("home.filter.publicOnly") },
+        ] : [];
+      case "organization":
+        return [
+          { key: null, label: t("home.filter.subAll") },
+          { key: "privateOnly", label: t("home.filter.privateOnly") },
+        ];
+      case "mine":
+        return [
+          { key: null, label: t("home.filter.notSharedOnly") },
+          { key: "shared", label: t("home.filter.sharedOnly") },
+          { key: "all", label: t("home.filter.subAll") },
+        ];
+      default:
+        return [];
+    }
+  }, [effectiveView, user, t]);
+
   if (isLoading && repositories.length === 0) {
     return (
       <div className={cn("w-full", className)}>
-        <h2 className="text-xl font-semibold mb-4">
-          {t("home.publicRepository.title")}
-        </h2>
+        {/* Filter tabs */}
+        <div className="flex flex-wrap items-center gap-2 mb-6">
+          {visibleTabs.map((tab) => (
+            <Button
+              key={tab.key}
+              variant={effectiveView === tab.key ? "default" : "outline"}
+              size="sm"
+              className="gap-1.5"
+              onClick={() => handleViewChange(tab.key)}
+            >
+              <tab.icon className="h-3.5 w-3.5" />
+              {tab.label}
+            </Button>
+          ))}
+        </div>
+        {/* Sub-filter chips */}
+        {subFilterOptions.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5 mb-4">
+            {subFilterOptions.map((sf) => (
+              <Button
+                key={sf.key ?? "all"}
+                variant={subFilter === sf.key ? "secondary" : "ghost"}
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => setSubFilter(sf.key)}
+              >
+                {sf.label}
+              </Button>
+            ))}
+          </div>
+        )}
+        <h2 className="text-xl font-semibold mb-4">{sectionTitle}</h2>
         <div className="mb-6">
           <div className="flex flex-wrap gap-2">
             {[1, 2, 3, 4, 5, 6].map((i) => (
@@ -111,9 +516,38 @@ export function PublicRepositoryList({ keyword, className }: PublicRepositoryLis
   if (error) {
     return (
       <div className={cn("w-full", className)}>
-        <h2 className="text-xl font-semibold mb-4">
-          {t("home.publicRepository.title")}
-        </h2>
+        {/* Filter tabs */}
+        <div className="flex flex-wrap items-center gap-2 mb-6">
+          {visibleTabs.map((tab) => (
+            <Button
+              key={tab.key}
+              variant={effectiveView === tab.key ? "default" : "outline"}
+              size="sm"
+              className="gap-1.5"
+              onClick={() => handleViewChange(tab.key)}
+            >
+              <tab.icon className="h-3.5 w-3.5" />
+              {tab.label}
+            </Button>
+          ))}
+        </div>
+        {/* Sub-filter chips */}
+        {subFilterOptions.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5 mb-4">
+            {subFilterOptions.map((sf) => (
+              <Button
+                key={sf.key ?? "all"}
+                variant={subFilter === sf.key ? "secondary" : "ghost"}
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => setSubFilter(sf.key)}
+              >
+                {sf.label}
+              </Button>
+            ))}
+          </div>
+        )}
+        <h2 className="text-xl font-semibold mb-4">{sectionTitle}</h2>
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <XCircle className="h-12 w-12 text-destructive mb-4" />
           <p className="text-muted-foreground mb-4">{t("home.publicRepository.loadError")}</p>
@@ -128,10 +562,66 @@ export function PublicRepositoryList({ keyword, className }: PublicRepositoryLis
 
   return (
     <div className={cn("w-full", className)}>
+      {/* Filter tabs */}
+      <div className="flex flex-wrap items-center gap-2 mb-6">
+        {visibleTabs.map((tab) => (
+          <Button
+            key={tab.key}
+            variant={effectiveView === tab.key ? "default" : "outline"}
+            size="sm"
+            className="gap-1.5"
+            onClick={() => handleViewChange(tab.key)}
+          >
+            <tab.icon className="h-3.5 w-3.5" />
+            {tab.label}
+          </Button>
+        ))}
+
+        {/* Action buttons for mine/organization views */}
+        {user && (effectiveView === "mine" || effectiveView === "organization") && (
+          <div className="ml-auto flex items-center gap-2">
+            <Link href="/private/github-import">
+              <Button variant="outline" size="sm" className="gap-1.5">
+                <GithubIcon className="h-3.5 w-3.5" />
+                {t("home.importFromGitHub")}
+              </Button>
+            </Link>
+            <Dialog open={isFormOpen} onOpenChange={setIsFormOpen}>
+              <Button
+                size="sm"
+                className="gap-1.5"
+                onClick={() => setIsFormOpen(true)}
+              >
+                <Plus className="h-3.5 w-3.5" />
+                {t("home.addPrivateRepo")}
+              </Button>
+              <DialogContent className="sm:max-w-md">
+                <RepositorySubmitForm onSuccess={handleSubmitSuccess} />
+              </DialogContent>
+            </Dialog>
+          </div>
+        )}
+      </div>
+
+      {/* Sub-filter chips */}
+      {subFilterOptions.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5 mb-4">
+          {subFilterOptions.map((sf) => (
+            <Button
+              key={sf.key ?? "all"}
+              variant={subFilter === sf.key ? "secondary" : "ghost"}
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => setSubFilter(sf.key)}
+            >
+              {sf.label}
+            </Button>
+          ))}
+        </div>
+      )}
+
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xl font-semibold">
-          {t("home.publicRepository.title")}
-        </h2>
+        <h2 className="text-xl font-semibold">{sectionTitle}</h2>
         <Button
           variant="ghost"
           size="icon"
@@ -147,14 +637,13 @@ export function PublicRepositoryList({ keyword, className }: PublicRepositoryLis
         selectedLanguage={selectedLanguage}
         onLanguageChange={handleLanguageChange}
         className="mb-6"
+        languages={viewLanguages ?? undefined}
       />
 
       {repositories.length === 0 && !keyword && !selectedLanguage ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <GitBranch className="h-12 w-12 text-muted-foreground mb-4" />
-          <p className="text-muted-foreground">
-            {t("home.publicRepository.empty")}
-          </p>
+          <p className="text-muted-foreground">{emptyMessage}</p>
         </div>
       ) : repositories.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
@@ -167,7 +656,15 @@ export function PublicRepositoryList({ keyword, className }: PublicRepositoryLis
         <>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {repositories.map((repo) => (
-              <PublicRepositoryCard key={repo.id} repository={repo} />
+              <PublicRepositoryCard
+                key={repo.id}
+                repository={repo}
+                {...(effectiveView === "mine"
+                  ? { onShareToggle: () => { setSubFilter("all"); }, toggleMode: "share" as const }
+                  : (effectiveView === "organization" && isAdmin)
+                    ? { onShareToggle: () => loadRepositories(), toggleMode: "restrict" as const }
+                    : {})}
+              />
             ))}
           </div>
 

--- a/web/components/repo/repo-shell.tsx
+++ b/web/components/repo/repo-shell.tsx
@@ -235,7 +235,8 @@ export function RepoShell({
     <DocsLayout
       tree={tree}
       nav={{
-        title,
+        title: "KeboolaDeepWiki",
+        url: "/",
       }}
       sidebar={{
         defaultOpenLevel: 1,

--- a/web/i18n/messages/en/home.json
+++ b/web/i18n/messages/en/home.json
@@ -161,5 +161,31 @@
       "ja": "Japanese",
       "ko": "Korean"
     }
+  },
+  "filter": {
+    "all": "All",
+    "public": "Public",
+    "organization": "Organization",
+    "myRepos": "My Repos",
+    "allTitle": "All Repositories",
+    "organizationTitle": "Organization Repositories",
+    "organizationEmpty": "No repositories shared with your departments",
+    "myReposEmpty": "You haven't added any repositories yet",
+    "shareWithOrg": "Share with organization",
+    "sharedWithOrg": "Shared with organization",
+    "unsharedFromOrg": "Removed from organization",
+    "restricted": "Restricted from organization",
+    "visibleToOrg": "Visible to organization",
+    "subAll": "All",
+    "publicOnly": "Public only",
+    "privateOnly": "Private only",
+    "sharedOnly": "Shared with org",
+    "notSharedOnly": "Not shared"
+  },
+  "icons": {
+    "public": "Public repository",
+    "organization": "Shared with organization",
+    "private": "Personal private repository",
+    "restricted": "Restricted - admin only"
   }
 }

--- a/web/i18n/messages/ja/home.json
+++ b/web/i18n/messages/ja/home.json
@@ -149,5 +149,31 @@
       "ja": "日本語",
       "ko": "韓国語"
     }
+  },
+  "filter": {
+    "all": "すべて",
+    "public": "公開",
+    "organization": "組織",
+    "myRepos": "マイリポジトリ",
+    "allTitle": "すべてのリポジトリ",
+    "organizationTitle": "組織リポジトリ",
+    "organizationEmpty": "部門で共有されているリポジトリはありません",
+    "myReposEmpty": "まだリポジトリを追加していません",
+    "shareWithOrg": "組織に共有",
+    "sharedWithOrg": "組織に共有されました",
+    "unsharedFromOrg": "組織から削除されました",
+    "restricted": "組織から制限",
+    "visibleToOrg": "組織に表示",
+    "subAll": "All",
+    "publicOnly": "Public only",
+    "privateOnly": "Private only",
+    "sharedOnly": "Shared with org",
+    "notSharedOnly": "Not shared"
+  },
+  "icons": {
+    "public": "パブリックリポジトリ",
+    "organization": "組織と共有",
+    "private": "個人プライベートリポジトリ",
+    "restricted": "制限 - 管理者のみ"
   }
 }

--- a/web/i18n/messages/ko/home.json
+++ b/web/i18n/messages/ko/home.json
@@ -149,5 +149,31 @@
       "ja": "일본어",
       "ko": "한국어"
     }
+  },
+  "filter": {
+    "all": "전체",
+    "public": "공개",
+    "organization": "조직",
+    "myRepos": "내 저장소",
+    "allTitle": "모든 저장소",
+    "organizationTitle": "조직 저장소",
+    "organizationEmpty": "부서에 공유된 저장소가 없습니다",
+    "myReposEmpty": "아직 추가한 저장소가 없습니다",
+    "shareWithOrg": "조직에 공유",
+    "sharedWithOrg": "조직에 공유됨",
+    "unsharedFromOrg": "조직에서 제거됨",
+    "restricted": "조직에서 제한됨",
+    "visibleToOrg": "조직에 표시",
+    "subAll": "All",
+    "publicOnly": "Public only",
+    "privateOnly": "Private only",
+    "sharedOnly": "Shared with org",
+    "notSharedOnly": "Not shared"
+  },
+  "icons": {
+    "public": "공개 저장소",
+    "organization": "조직과 공유됨",
+    "private": "개인 비공개 저장소",
+    "restricted": "제한됨 - 관리자만"
   }
 }

--- a/web/i18n/messages/zh/home.json
+++ b/web/i18n/messages/zh/home.json
@@ -161,5 +161,31 @@
       "ja": "日语",
       "ko": "韩语"
     }
+  },
+  "filter": {
+    "all": "全部",
+    "public": "公开",
+    "organization": "组织",
+    "myRepos": "我的仓库",
+    "allTitle": "所有仓库",
+    "organizationTitle": "组织仓库",
+    "organizationEmpty": "您的部门没有共享的仓库",
+    "myReposEmpty": "您还没有添加任何仓库",
+    "shareWithOrg": "共享给组织",
+    "sharedWithOrg": "已共享给组织",
+    "unsharedFromOrg": "已从组织移除",
+    "restricted": "已从组织中限制",
+    "visibleToOrg": "对组织可见",
+    "subAll": "All",
+    "publicOnly": "Public only",
+    "privateOnly": "Private only",
+    "sharedOnly": "Shared with org",
+    "notSharedOnly": "Not shared"
+  },
+  "icons": {
+    "public": "公共仓库",
+    "organization": "已共享给组织",
+    "private": "个人私有仓库",
+    "restricted": "已限制 - 仅管理员可见"
   }
 }

--- a/web/lib/organization-api.ts
+++ b/web/lib/organization-api.ts
@@ -1,6 +1,16 @@
 import { getToken } from "./auth-api";
 import { getApiProxyUrl } from "./env";
 
+/**
+ * Organization API client.
+ *
+ * Admin restrict/unrestrict endpoints require AdminOnly authorization policy,
+ * so they MUST use fetchWithAuth (Bearer token), not raw fetch with credentials.
+ *
+ * DepartmentRepository.isPublic comes from backend's Repository.IsPublic,
+ * enabling dual-icon display (Globe + Building2) for public org repos.
+ */
+
 const API_BASE_URL = getApiProxyUrl();
 
 function buildApiUrl(path: string) {
@@ -48,6 +58,10 @@ export interface DepartmentRepository {
   statusName: string;
   departmentId: string;
   departmentName: string;
+  createdAt?: string;
+  primaryLanguage?: string;
+  isRestricted?: boolean;
+  isPublic?: boolean;
 }
 
 /**
@@ -62,8 +76,29 @@ export async function getMyDepartments(): Promise<UserDepartment[]> {
 /**
  * 获取当前用户部门下的仓库列表
  */
-export async function getMyDepartmentRepositories(): Promise<DepartmentRepository[]> {
-  const url = buildApiUrl("/api/organizations/my-repositories");
+export async function getMyDepartmentRepositories(includeRestricted = false): Promise<DepartmentRepository[]> {
+  const params = includeRestricted ? '?includeRestricted=true' : '';
+  const url = buildApiUrl(`/api/organizations/my-repositories${params}`);
   const result = await fetchWithAuth(url);
   return result.data;
+}
+
+export async function shareRepoWithOrganization(repositoryId: string): Promise<{ success: boolean }> {
+  const url = buildApiUrl(`/api/organizations/my-repositories/${repositoryId}/share`);
+  return fetchWithAuth(url, { method: "POST" });
+}
+
+export async function unshareRepoFromOrganization(repositoryId: string): Promise<{ success: boolean }> {
+  const url = buildApiUrl(`/api/organizations/my-repositories/${repositoryId}/share`);
+  return fetchWithAuth(url, { method: "DELETE" });
+}
+
+export async function restrictRepoInOrganization(repositoryId: string): Promise<{ success: boolean }> {
+  const url = buildApiUrl(`/api/organizations/repositories/${repositoryId}/restrict`);
+  return fetchWithAuth(url, { method: "POST" });
+}
+
+export async function unrestrictRepoInOrganization(repositoryId: string): Promise<{ success: boolean }> {
+  const url = buildApiUrl(`/api/organizations/repositories/${repositoryId}/unrestrict`);
+  return fetchWithAuth(url, { method: "POST" });
 }

--- a/web/types/repository.ts
+++ b/web/types/repository.ts
@@ -81,6 +81,8 @@ export interface RepositoryItemResponse {
   starCount?: number;
   forkCount?: number;
   primaryLanguage?: string;
+  departmentName?: string;
+  isRestricted?: boolean;
 }
 
 export interface RepositoryListResponse {


### PR DESCRIPTION
## Summary

Replaces the separate public/private repository pages with a unified dashboard featuring organization-level repository management.

### New features

- **4 view tabs**: All, Public, Organization, My Repos -- unified single-page dashboard
- **Dual icons**: repos that are both public AND in a department show Globe + Building2 icons side-by-side
- **Sub-filter chips**: contextual filters within each view:
  - Public: All / Public only (excludes org repos)
  - Organization: All / Private only (excludes public repos)
  - My Repos: Not shared (default) / Shared with org / All
- **Organization sharing**: users can share personal repos with their departments
- **Admin restrict/unrestrict**: admins can toggle repo visibility for non-admin users
- **Race condition protection**: loadIdRef counter prevents stale async responses from overwriting newer data
- **Stale state clearing**: view switches immediately clear previous view's data (no flash)

### Backend changes

- New `OrganizationEndpoints`: share, unshare, restrict, unrestrict endpoints
- New `OrganizationService` with department-based repository access control
- `DepartmentRepositoryInfo` DTO with `IsPublic` and `IsRestricted` fields
- Admin-only authorization policy for restrict/unrestrict

### Frontend changes

- Unified `PublicRepositoryList` component with 4 views + sub-filters + client/server-side pagination
- `PublicRepositoryCard` with dual icons and context-aware share/restrict toggles
- Organization API client (`organization-api.ts`) with authenticated requests
- i18n keys for all new UI text (en, zh, ko, ja)

### Architecture decisions (documented in code)

- Public API doesn't include `departmentName`, so public view enriches results from dept data
- GitHub App imports set `OwnerUserId` to importing admin; Mine view subtracts dept repos by default
- Sub-filters applied client-side after fetching; Public default uses server-side pagination