### PR TITLE
Fix SSR auth for private repository pages

### DIFF
--- a/web/lib/auth-api.ts
+++ b/web/lib/auth-api.ts
@@ -60,13 +60,14 @@ export function getToken(): string | null {
 /**
  * Read JWT from cookie during SSR. Uses require() to avoid build errors
  * when this module is imported in client components.
+ * Must be async because cookies() returns a Promise in Next.js 15+.
  */
-export function getServerToken(): string | null {
+export async function getServerToken(): Promise<string | null> {
   if (typeof window !== "undefined") return null;
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { cookies } = require("next/headers");
-    const cookieStore = cookies();
+    const cookieStore = await cookies();
     return cookieStore.get(TOKEN_COOKIE)?.value ?? null;
   } catch {
     return null;

--- a/web/lib/repository-api.ts
+++ b/web/lib/repository-api.ts
@@ -19,9 +19,10 @@ import { getServerToken } from "./auth-api";
  * Returns Authorization header for SSR fetches if a JWT cookie is present.
  * On the client side (window exists), getServerToken() returns null so
  * this returns empty headers -- client auth goes through apiClient instead.
+ * Async because cookies() is async in Next.js 15+.
  */
-function getSSRAuthHeaders(): HeadersInit {
-  const token = getServerToken();
+async function getSSRAuthHeaders(): Promise<HeadersInit> {
+  const token = await getServerToken();
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
@@ -37,7 +38,7 @@ export async function fetchRepoBranches(owner: string, repo: string) {
     `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/branches`,
   );
 
-  const response = await fetch(url, { cache: "no-store", headers: getSSRAuthHeaders() });
+  const response = await fetch(url, { cache: "no-store", headers: await getSSRAuthHeaders() });
 
   if (!response.ok) {
     throw new Error("Failed to fetch repository branches");
@@ -55,7 +56,7 @@ export async function fetchGitBranches(gitUrl: string): Promise<GitBranchesRespo
   
   const url = buildApiUrl(`/api/v1/repositories/branches?${params.toString()}`);
 
-  const response = await fetch(url, { cache: "no-store", headers: getSSRAuthHeaders() });
+  const response = await fetch(url, { cache: "no-store", headers: await getSSRAuthHeaders() });
 
   if (!response.ok) {
     return { branches: [], defaultBranch: null, isSupported: false };
@@ -74,7 +75,7 @@ export async function fetchRepoTree(owner: string, repo: string, branch?: string
     `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/tree${queryString ? `?${queryString}` : ""}`,
   );
 
-  const response = await fetch(url, { cache: "no-store", headers: getSSRAuthHeaders() });
+  const response = await fetch(url, { cache: "no-store", headers: await getSSRAuthHeaders() });
 
   if (!response.ok) {
     throw new Error("Failed to fetch repository tree");
@@ -94,7 +95,7 @@ export async function fetchRepoDoc(owner: string, repo: string, slug: string, br
     `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/docs/${encodedSlug}${queryString ? `?${queryString}` : ""}`,
   );
 
-  const response = await fetch(url, { cache: "no-store", headers: getSSRAuthHeaders() });
+  const response = await fetch(url, { cache: "no-store", headers: await getSSRAuthHeaders() });
 
   if (!response.ok) {
     throw new Error("Failed to fetch repository doc");
@@ -144,7 +145,7 @@ export async function fetchRepositoryList(params?: {
   const queryString = searchParams.toString();
   const url = buildApiUrl(`/api/v1/repositories/list${queryString ? `?${queryString}` : ""}`);
 
-  const response = await fetch(url, { cache: "no-store", headers: getSSRAuthHeaders() });
+  const response = await fetch(url, { cache: "no-store", headers: await getSSRAuthHeaders() });
 
   if (!response.ok) {
     throw new Error("Failed to fetch repository list");
@@ -172,7 +173,7 @@ export async function fetchRepoStatus(owner: string, repo: string): Promise<Repo
     `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/tree`,
   );
 
-  const response = await fetch(url, { cache: "no-store", headers: getSSRAuthHeaders() });
+  const response = await fetch(url, { cache: "no-store", headers: await getSSRAuthHeaders() });
 
   if (!response.ok) {
     throw new Error("Failed to fetch repository status");
@@ -202,7 +203,7 @@ export async function fetchProcessingLogs(
     `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/processing-logs${queryString ? `?${queryString}` : ""}`
   );
 
-  const response = await fetch(url, { cache: "no-store", headers: getSSRAuthHeaders() });
+  const response = await fetch(url, { cache: "no-store", headers: await getSSRAuthHeaders() });
 
   if (!response.ok) {
     throw new Error("Failed to fetch processing logs");
@@ -223,7 +224,7 @@ export async function checkGitHubRepo(
     `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/check`
   );
 
-  const response = await fetch(url, { cache: "no-store", headers: getSSRAuthHeaders() });
+  const response = await fetch(url, { cache: "no-store", headers: await getSSRAuthHeaders() });
 
   if (!response.ok) {
     return {
@@ -276,7 +277,7 @@ export async function fetchMindMap(
     `/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/mindmap${queryString ? `?${queryString}` : ""}`
   );
 
-  const response = await fetch(url, { cache: "no-store", headers: getSSRAuthHeaders() });
+  const response = await fetch(url, { cache: "no-store", headers: await getSSRAuthHeaders() });
 
   if (!response.ok) {
     throw new Error("Failed to fetch mind map");


### PR DESCRIPTION
## Summary

Private repositories show "Repository Not Found" when users navigate directly to a repo URL (e.g., `/owner/repo`) because Next.js Server Components call fetch without an Authorization header. The JWT token was stored only in `localStorage`, which is inaccessible during SSR.

## Changes

### `web/lib/auth-api.ts`
- Store JWT in a cookie (`deepwiki_token`) alongside `localStorage` on login
- Clear cookie on logout
- Add `getServerToken()` that reads the cookie via `next/headers` during SSR

### `web/lib/repository-api.ts`
- Add `getSSRAuthHeaders()` helper that returns `Authorization: Bearer <token>` if a cookie is present
- Inject auth headers in all SSR fetch functions: `fetchRepoTree`, `fetchRepoBranches`, `fetchRepoDoc`, `checkGitHubRepo`, `fetchRepoStatus`, `fetchProcessingLogs`, `fetchRepositoryList`, `fetchGitBranches`, `fetchMindMap`

## How it works

1. User logs in -> `setToken()` sets both `localStorage` and cookie
2. User navigates to `/owner/private-repo` -> SSR calls `fetchRepoTree()`
3. `getSSRAuthHeaders()` calls `getServerToken()` which reads cookie via `next/headers`
4. Fetch includes `Authorization: Bearer <jwt>` header -> backend returns repo data
5. On client side, `getServerToken()` returns null (window exists), so client-side auth continues via `apiClient` + `localStorage` as before

## Test plan
- [ ] Log in, navigate to private repo URL directly -> shows repo content
- [ ] Open private repo URL in incognito (no login) -> shows "Repository Not Found"
- [ ] Public repos still work without login
- [ ] Log out, then navigate to private repo -> shows "Repository Not Found"