### PR TITLE
Add URL encoding support for repository routes

### DIFF
--- a/src/OpenDeepWiki/Infrastructure/RepositoryRouteDecoder.cs
+++ b/src/OpenDeepWiki/Infrastructure/RepositoryRouteDecoder.cs
@@ -1,0 +1,26 @@
+namespace OpenDeepWiki.Infrastructure;
+
+public static class RepositoryRouteDecoder
+{
+    public static (string Owner, string Repo) DecodeOwnerAndRepo(string owner, string repo)
+    {
+        return (DecodeRouteSegment(owner), DecodeRouteSegment(repo));
+    }
+
+    public static string DecodeRouteSegment(string value)
+    {
+        if (string.IsNullOrEmpty(value) || !value.Contains('%'))
+        {
+            return value;
+        }
+
+        try
+        {
+            return Uri.UnescapeDataString(value);
+        }
+        catch (Exception)
+        {
+            return value;
+        }
+    }
+}

--- a/src/OpenDeepWiki/Services/MindMap/MindMapApiService.cs
+++ b/src/OpenDeepWiki/Services/MindMap/MindMapApiService.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenDeepWiki.EFCore;
 using OpenDeepWiki.Entities;
+using OpenDeepWiki.Infrastructure;
 
 namespace OpenDeepWiki.Services.MindMap;
 
@@ -22,6 +23,8 @@ public class MindMapApiService(IContext context)
         [FromQuery] string? branch,
         [FromQuery] string? lang)
     {
+        (owner, repo) = RepositoryRouteDecoder.DecodeOwnerAndRepo(owner, repo);
+
         var repository = await context.Repositories
             .AsNoTracking()
             .FirstOrDefaultAsync(r => r.OrgName == owner && r.RepoName == repo);
@@ -76,6 +79,7 @@ public class MindMapApiService(IContext context)
             Content = branchLanguage.MindMapContent
         });
     }
+
 }
 
 /// <summary>

--- a/src/OpenDeepWiki/Services/Repositories/ProcessingLogApiService.cs
+++ b/src/OpenDeepWiki/Services/Repositories/ProcessingLogApiService.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenDeepWiki.EFCore;
 using OpenDeepWiki.Entities;
+using OpenDeepWiki.Infrastructure;
 
 namespace OpenDeepWiki.Services.Repositories;
 
@@ -22,6 +23,8 @@ public class ProcessingLogApiService(IContext context, IProcessingLogService pro
         [FromQuery] DateTime? since,
         [FromQuery] int limit = 100)
     {
+        (owner, repo) = RepositoryRouteDecoder.DecodeOwnerAndRepo(owner, repo);
+
         if (limit <= 0) limit = 100;
         if (limit > 500) limit = 500;
 
@@ -57,6 +60,7 @@ public class ProcessingLogApiService(IContext context, IProcessingLogService pro
             }).ToList()
         });
     }
+
 }
 
 /// <summary>

--- a/src/OpenDeepWiki/Services/Repositories/RepositoryDocsService.cs
+++ b/src/OpenDeepWiki/Services/Repositories/RepositoryDocsService.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using OpenDeepWiki.Cache.Abstractions;
 using OpenDeepWiki.EFCore;
 using OpenDeepWiki.Entities;
+using OpenDeepWiki.Infrastructure;
 using OpenDeepWiki.Models;
 using System.IO.Compression;
 using System.Text;
@@ -27,9 +28,9 @@ public class RepositoryDocsService(IContext context, IGitPlatformService gitPlat
     [HttpGet("/{owner}/{repo}/branches")]
     public async Task<RepositoryBranchesResponse> GetBranchesAsync(string owner, string repo)
     {
-        var repository = await context.Repositories
-            .AsNoTracking()
-            .FirstOrDefaultAsync(item => item.OrgName == owner && item.RepoName == repo);
+        (owner, repo) = RepositoryRouteDecoder.DecodeOwnerAndRepo(owner, repo);
+
+        var repository = await GetRepositoryAsync(owner, repo);
 
         if (repository is null)
         {
@@ -100,9 +101,9 @@ public class RepositoryDocsService(IContext context, IGitPlatformService gitPlat
     [HttpGet("/{owner}/{repo}/tree")]
     public async Task<RepositoryTreeResponse> GetTreeAsync(string owner, string repo, [FromQuery] string? branch = null, [FromQuery] string? lang = null)
     {
-        var repository = await context.Repositories
-            .AsNoTracking()
-            .FirstOrDefaultAsync(item => item.OrgName == owner && item.RepoName == repo);
+        (owner, repo) = RepositoryRouteDecoder.DecodeOwnerAndRepo(owner, repo);
+
+        var repository = await GetRepositoryAsync(owner, repo);
 
         // 仓库不存在
         if (repository is null)
@@ -194,6 +195,7 @@ public class RepositoryDocsService(IContext context, IGitPlatformService gitPlat
     [HttpGet("/{owner}/{repo}/docs/{*slug}")]
     public async Task<RepositoryDocResponse> GetDocAsync(string owner, string repo, string slug, [FromQuery] string? branch = null, [FromQuery] string? lang = null)
     {
+        (owner, repo) = RepositoryRouteDecoder.DecodeOwnerAndRepo(owner, repo);
         var normalizedSlug = NormalizePath(slug);
 
         var repository = await GetRepositoryAsync(owner, repo);
@@ -261,6 +263,7 @@ public class RepositoryDocsService(IContext context, IGitPlatformService gitPlat
     [HttpGet("/{owner}/{repo}/check")]
     public async Task<GitRepoCheckResponse> CheckRepoAsync(string owner, string repo)
     {
+        (owner, repo) = RepositoryRouteDecoder.DecodeOwnerAndRepo(owner, repo);
         var repoInfo = await gitPlatformService.CheckRepoExistsAsync(owner, repo);
         
         return new GitRepoCheckResponse
@@ -421,6 +424,7 @@ public class RepositoryDocsService(IContext context, IGitPlatformService gitPlat
     [Authorize]
     public async Task<IActionResult> ExportAsync(string owner, string repo, [FromQuery] string? branch = null, [FromQuery] string? lang = null)
     {
+        (owner, repo) = RepositoryRouteDecoder.DecodeOwnerAndRepo(owner, repo);
         var repository = await GetRepositoryAsync(owner, repo);
         if (repository is null)
         {

--- a/src/OpenDeepWiki/Services/Wiki/WikiService.cs
+++ b/src/OpenDeepWiki/Services/Wiki/WikiService.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenDeepWiki.EFCore;
 using OpenDeepWiki.Entities;
+using OpenDeepWiki.Infrastructure;
 using OpenDeepWiki.Models;
 
 namespace OpenDeepWiki.Services.Wiki;
@@ -18,6 +19,7 @@ public class WikiService(IContext context)
     [HttpGet("/{org}/{repo}/catalog")]
     public async Task<WikiCatalogResponse> GetCatalogAsync(string org, string repo)
     {
+        (org, repo) = RepositoryRouteDecoder.DecodeOwnerAndRepo(org, repo);
         var repository = await GetRepositoryAsync(org, repo);
         var branch = await GetDefaultBranchAsync(repository.Id);
         var language = await GetDefaultLanguageAsync(branch.Id);
@@ -51,6 +53,7 @@ public class WikiService(IContext context)
     [HttpGet("/{org}/{repo}/doc/{*path}")]
     public async Task<WikiDocResponse> GetDocAsync(string org, string repo, string path)
     {
+        (org, repo) = RepositoryRouteDecoder.DecodeOwnerAndRepo(org, repo);
         var repository = await GetRepositoryAsync(org, repo);
         var branch = await GetDefaultBranchAsync(repository.Id);
         var language = await GetDefaultLanguageAsync(branch.Id);
@@ -170,4 +173,5 @@ public class WikiService(IContext context)
     {
         return path.Trim().Trim('/');
     }
+
 }

--- a/tests/OpenDeepWiki.Tests/Infrastructure/RepositoryRouteDecoderUnitTests.cs
+++ b/tests/OpenDeepWiki.Tests/Infrastructure/RepositoryRouteDecoderUnitTests.cs
@@ -1,0 +1,35 @@
+using OpenDeepWiki.Infrastructure;
+using Xunit;
+
+namespace OpenDeepWiki.Tests.Infrastructure;
+
+public class RepositoryRouteDecoderUnitTests
+{
+    [Fact]
+    public void DecodeRouteSegment_EncodedValue_ReturnsDecodedValue()
+    {
+        var result = RepositoryRouteDecoder.DecodeRouteSegment("hello%20world");
+
+        Assert.Equal("hello world", result);
+    }
+
+    [Fact]
+    public void DecodeRouteSegment_ValueWithoutPercent_ReturnsOriginalValue()
+    {
+        const string value = "hello world";
+
+        var result = RepositoryRouteDecoder.DecodeRouteSegment(value);
+
+        Assert.Equal(value, result);
+    }
+
+    [Fact]
+    public void DecodeRouteSegment_InvalidEncoding_ReturnsOriginalValue()
+    {
+        const string value = "hello%2";
+
+        var result = RepositoryRouteDecoder.DecodeRouteSegment(value);
+
+        Assert.Equal(value, result);
+    }
+}

--- a/web/app/(main)/bookmarks/page.tsx
+++ b/web/app/(main)/bookmarks/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Bookmark, Star, GitFork, Trash2, Loader2 } from "lucide-react";
 import { useAuth } from "@/contexts/auth-context";
 import { getUserBookmarks, removeBookmark, BookmarkItemResponse } from "@/lib/bookmark-api";
+import { buildRepoBasePath } from "@/lib/repo-route";
 
 export default function BookmarksPage() {
   const t = useTranslations();
@@ -128,7 +129,7 @@ export default function BookmarksPage() {
               {bookmarks.map((repo) => (
                 <Link 
                   key={repo.bookmarkId} 
-                  href={`/${encodeURIComponent(repo.orgName)}/${encodeURIComponent(repo.repoName)}`}
+                  href={buildRepoBasePath(repo.orgName, repo.repoName)}
                   className="block"
                 >
                   <Card className="hover:shadow-lg transition-shadow cursor-pointer h-full">

--- a/web/app/(main)/organizations/page.tsx
+++ b/web/app/(main)/organizations/page.tsx
@@ -24,6 +24,7 @@ import {
   AlertCircle,
 } from "lucide-react";
 import { toast } from "sonner";
+import { buildRepoBasePath } from "@/lib/repo-route";
 
 const statusConfig: Record<string, { icon: React.ElementType; color: string; label: string }> = {
   Pending: { icon: Clock, color: "text-yellow-500", label: "等待处理" },
@@ -160,7 +161,7 @@ export default function OrganizationsPage() {
                     </div>
                     <div className="mt-4 flex gap-2">
                       {repo.statusName === "Completed" && (
-                        <Link href={`/${repo.orgName}/${repo.repoName}`}>
+                        <Link href={buildRepoBasePath(repo.orgName, repo.repoName)}>
                           <Button size="sm" variant="outline">
                             <ExternalLink className="mr-1 h-3 w-3" />
                             查看文档

--- a/web/app/(main)/recommend/page.tsx
+++ b/web/app/(main)/recommend/page.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/lib/recommendation-api";
 import { useAuth } from "@/contexts/auth-context";
 import Link from "next/link";
+import { buildRepoBasePath } from "@/lib/repo-route";
 
 type Strategy = "default" | "popular" | "personalized" | "explore";
 
@@ -254,7 +255,7 @@ export default function RecommendPage() {
             {repos.map((repo) => (
               <Link 
                 key={repo.id} 
-                href={`/${repo.orgName}/${repo.repoName}`}
+                href={buildRepoBasePath(repo.orgName, repo.repoName)}
                 className="block"
                 onClick={() => handleRepoClick(repo)}
               >

--- a/web/app/[owner]/[repo]/[...slug]/page.tsx
+++ b/web/app/[owner]/[repo]/[...slug]/page.tsx
@@ -5,6 +5,7 @@ import { DocNotFound } from "@/components/repo/doc-not-found";
 import { SourceFiles } from "@/components/repo/source-files";
 import { DocsPage, DocsBody } from "fumadocs-ui/page";
 import type { TOCItemType } from "fumadocs-core/toc";
+import { decodeRouteSegment } from "@/lib/repo-route";
 
 interface RepoDocPageProps {
   params: Promise<{
@@ -33,12 +34,14 @@ async function getDocData(owner: string, repo: string, slug: string, branch?: st
 
 export default async function RepoDocPage({ params, searchParams }: RepoDocPageProps) {
   const { owner, repo, slug: slugParts } = await params;
+  const decodedOwner = decodeRouteSegment(owner);
+  const decodedRepo = decodeRouteSegment(repo);
   const resolvedSearchParams = await searchParams;
   const branch = resolvedSearchParams?.branch;
   const lang = resolvedSearchParams?.lang;
   const slug = slugParts.join("/");
 
-  const data = await getDocData(owner, repo, slug, branch, lang);
+  const data = await getDocData(decodedOwner, decodedRepo, slug, branch, lang);
   
   // 文档不存在，但保留侧边栏（由layout提供）
   if (!data) {

--- a/web/app/[owner]/[repo]/layout.tsx
+++ b/web/app/[owner]/[repo]/layout.tsx
@@ -4,6 +4,7 @@ import { RepoShell } from "@/components/repo/repo-shell";
 import { RepositoryProcessingStatus } from "@/components/repo/repository-processing-status";
 import { RepositoryNotFound } from "@/components/repo/repository-not-found";
 import { RootProvider } from "fumadocs-ui/provider/next";
+import { decodeRouteSegment } from "@/lib/repo-route";
 
 // 禁用缓存
 export const dynamic = "force-dynamic";
@@ -44,21 +45,23 @@ async function getGitHubInfo(owner: string, repo: string) {
 
 export default async function RepoLayout({ children, params }: RepoLayoutProps) {
   const { owner, repo } = await params;
+  const decodedOwner = decodeRouteSegment(owner);
+  const decodedRepo = decodeRouteSegment(repo);
   
-  const tree = await getTreeData(owner, repo);
+  const tree = await getTreeData(decodedOwner, decodedRepo);
   
   // API请求失败或仓库不存在，检查GitHub
   if (!tree || !tree.exists) {
-    const gitHubInfo = await getGitHubInfo(owner, repo);
-    return <RepositoryNotFound owner={owner} repo={repo} gitHubInfo={gitHubInfo} />;
+    const gitHubInfo = await getGitHubInfo(decodedOwner, decodedRepo);
+    return <RepositoryNotFound owner={decodedOwner} repo={decodedRepo} gitHubInfo={gitHubInfo} />;
   }
 
   // 仓库正在处理中或等待处理
   if (tree.statusName === "Pending" || tree.statusName === "Processing" || tree.statusName === "Failed") {
     return (
       <RepositoryProcessingStatus
-        owner={owner}
-        repo={repo}
+        owner={decodedOwner}
+        repo={decodedRepo}
         status={tree.statusName}
       />
     );
@@ -68,21 +71,21 @@ export default async function RepoLayout({ children, params }: RepoLayoutProps) 
   if (tree.nodes.length === 0) {
     return (
       <RepositoryProcessingStatus
-        owner={owner}
-        repo={repo}
+        owner={decodedOwner}
+        repo={decodedRepo}
         status="Completed"
       />
     );
   }
 
   // 获取分支和语言数据
-  const branches = await getBranchesData(owner, repo);
+  const branches = await getBranchesData(decodedOwner, decodedRepo);
 
   return (
     <RootProvider>
       <RepoShell 
-        owner={owner} 
-        repo={repo} 
+        owner={decodedOwner} 
+        repo={decodedRepo} 
         initialNodes={tree.nodes}
         initialBranches={branches ?? undefined}
         initialBranch={tree.currentBranch}

--- a/web/app/[owner]/[repo]/mindmap/page.tsx
+++ b/web/app/[owner]/[repo]/mindmap/page.tsx
@@ -1,5 +1,6 @@
 import { fetchMindMap } from "@/lib/repository-api";
 import { MindMapPageContent } from "@/components/repo/mindmap-page-content";
+import { decodeRouteSegment } from "@/lib/repo-route";
 
 interface MindMapPageProps {
   params: Promise<{
@@ -22,16 +23,18 @@ async function getMindMapData(owner: string, repo: string, branch?: string, lang
 
 export default async function MindMapPage({ params, searchParams }: MindMapPageProps) {
   const { owner, repo } = await params;
+  const decodedOwner = decodeRouteSegment(owner);
+  const decodedRepo = decodeRouteSegment(repo);
   const resolvedSearchParams = await searchParams;
   const branch = resolvedSearchParams?.branch;
   const lang = resolvedSearchParams?.lang;
 
-  const mindMap = await getMindMapData(owner, repo, branch, lang);
+  const mindMap = await getMindMapData(decodedOwner, decodedRepo, branch, lang);
 
   return (
     <MindMapPageContent
-      owner={owner}
-      repo={repo}
+      owner={decodedOwner}
+      repo={decodedRepo}
       mindMap={mindMap}
     />
   );

--- a/web/app/[owner]/[repo]/page.tsx
+++ b/web/app/[owner]/[repo]/page.tsx
@@ -2,19 +2,13 @@ import { redirect } from "next/navigation";
 import { fetchRepoTree } from "@/lib/repository-api";
 import { DocNotFound } from "@/components/repo/doc-not-found";
 import { DocsPage, DocsBody } from "fumadocs-ui/page";
+import { buildRepoDocPath, decodeRouteSegment } from "@/lib/repo-route";
 
 interface RepoIndexProps {
   params: Promise<{
     owner: string;
     repo: string;
   }>;
-}
-
-function encodeSlug(slug: string) {
-  return slug
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/");
 }
 
 async function getTreeData(owner: string, repo: string) {
@@ -27,8 +21,10 @@ async function getTreeData(owner: string, repo: string) {
 
 export default async function RepoIndex({ params }: RepoIndexProps) {
   const { owner, repo } = await params;
+  const decodedOwner = decodeRouteSegment(owner);
+  const decodedRepo = decodeRouteSegment(repo);
   
-  const tree = await getTreeData(owner, repo);
+  const tree = await getTreeData(decodedOwner, decodedRepo);
   
   // API错误，layout会处理
   if (!tree) {
@@ -47,7 +43,7 @@ export default async function RepoIndex({ params }: RepoIndexProps) {
 
   // 有默认文档，重定向
   if (tree.defaultSlug) {
-    redirect(`/${owner}/${repo}/${encodeSlug(tree.defaultSlug)}`);
+    redirect(buildRepoDocPath(decodedOwner, decodedRepo, tree.defaultSlug));
   }
 
   // 没有默认文档但有目录，显示提示

--- a/web/components/repo/public-repository-card.tsx
+++ b/web/components/repo/public-repository-card.tsx
@@ -20,6 +20,7 @@ import {
   GitFork,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { buildRepoBasePath } from "@/lib/repo-route";
 import { addBookmark, removeBookmark, getBookmarkStatus } from "@/lib/bookmark-api";
 import { addSubscription, removeSubscription, getSubscriptionStatus } from "@/lib/subscription-api";
 import { toast } from "sonner";
@@ -80,6 +81,7 @@ export function PublicRepositoryCard({ repository }: PublicRepositoryCardProps) 
   const t = useTranslations();
   const { user } = useAuth();
   const createdDate = new Date(repository.createdAt).toLocaleDateString();
+  const wikiUrl = buildRepoBasePath(repository.orgName, repository.repoName);
 
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [isSubscribed, setIsSubscribed] = useState(false);
@@ -153,7 +155,7 @@ export function PublicRepositoryCard({ repository }: PublicRepositoryCardProps) 
   }, [user, repository.id, isSubscribed, subscribeLoading, t]);
 
   return (
-    <Link href={`/${repository.orgName}/${repository.repoName}`}>
+    <Link href={wikiUrl}>
       <Card className="h-full transition-all hover:shadow-md hover:border-primary/50 cursor-pointer">
         <CardContent className="p-4">
           <div className="flex flex-col gap-3">

--- a/web/components/repo/repo-shell.tsx
+++ b/web/components/repo/repo-shell.tsx
@@ -11,6 +11,7 @@ import { fetchRepoTree, fetchRepoBranches } from "@/lib/repository-api";
 import { Network, Download } from "lucide-react";
 import { ChatAssistant, buildCatalogMenu } from "@/components/chat";
 import { useTranslations } from "@/hooks/use-translations";
+import { buildRepoBasePath, buildRepoDocPath, buildRepoMindMapPath } from "@/lib/repo-route";
 
 interface RepoShellProps {
   owner: string;
@@ -31,7 +32,7 @@ function convertToPageTreeNode(
   repo: string,
   queryString: string
 ): PageTree.Node {
-  const baseUrl = `/${owner}/${repo}/${node.slug}`;
+  const baseUrl = buildRepoDocPath(owner, repo, node.slug);
   // 链接需要带上查询参数以保持 branch 和 lang 状态
   const url = queryString ? `${baseUrl}?${queryString}` : baseUrl;
 
@@ -82,6 +83,7 @@ export function RepoShell({
   const urlBranch = searchParams.get("branch");
   const urlLang = searchParams.get("lang");
   const t = useTranslations();
+  const repoBasePath = buildRepoBasePath(owner, repo);
   
   const [nodes, setNodes] = useState<RepoTreeNode[]>(initialNodes);
   const [branches, setBranches] = useState<RepoBranchesResponse | undefined>(initialBranches);
@@ -93,12 +95,17 @@ export function RepoShell({
   // 从pathname提取当前文档路径
   const currentDocPath = React.useMemo(() => {
     // pathname格式: /owner/repo/slug 或 /owner/repo/path/to/doc
-    const prefix = `/${owner}/${repo}/`;
-    if (pathname.startsWith(prefix)) {
-      return pathname.slice(prefix.length);
+    const encodedPrefix = `${repoBasePath}/`;
+    if (pathname.startsWith(encodedPrefix)) {
+      return pathname.slice(encodedPrefix.length);
+    }
+
+    const rawPrefix = `/${owner}/${repo}/`;
+    if (pathname.startsWith(rawPrefix)) {
+      return pathname.slice(rawPrefix.length);
     }
     return "";
-  }, [pathname, owner, repo]);
+  }, [pathname, owner, repo, repoBasePath]);
 
   // 当 URL 参数变化时，重新获取数据
   useEffect(() => {
@@ -146,8 +153,8 @@ export function RepoShell({
 
   // 构建思维导图链接
   const mindMapUrl = queryString 
-    ? `/${owner}/${repo}/mindmap?${queryString}` 
-    : `/${owner}/${repo}/mindmap`;
+    ? `${buildRepoMindMapPath(owner, repo)}?${queryString}`
+    : buildRepoMindMapPath(owner, repo);
 
   // 导出功能处理
   const handleExport = async () => {

--- a/web/components/repo/repo-sidebar.tsx
+++ b/web/components/repo/repo-sidebar.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/animate-ui/components/radix/sidebar";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type { RepoTreeNode } from "@/types/repository";
+import { buildRepoBasePath, encodeSlugPath } from "@/lib/repo-route";
 
 interface RepoSidebarProps {
   owner: string;
@@ -23,23 +24,16 @@ interface RepoSidebarProps {
   nodes: RepoTreeNode[];
 }
 
-function encodeSlug(slug: string) {
-  return slug
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/");
-}
-
 export function RepoSidebar({ owner, repo, nodes }: RepoSidebarProps) {
   const params = useParams<{ slug?: string | string[] }>();
   const searchParams = useSearchParams();
   const slugParam = params?.slug;
   const activeSlug = Array.isArray(slugParam) ? slugParam.join("/") : slugParam ?? "";
-  const basePath = `/${owner}/${repo}`;
+  const basePath = buildRepoBasePath(owner, repo);
 
   // 构建带查询参数的链接
   const buildHref = (slug: string) => {
-    const path = `${basePath}/${encodeSlug(slug)}`;
+    const path = `${basePath}/${encodeSlugPath(slug)}`;
     const queryString = searchParams.toString();
     return queryString ? `${path}?${queryString}` : path;
   };

--- a/web/components/repo/repository-list.tsx
+++ b/web/components/repo/repository-list.tsx
@@ -24,6 +24,7 @@ import {
   GitBranch,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { buildRepoBasePath } from "@/lib/repo-route";
 import { VisibilityToggle } from "@/components/repo/visibility-toggle";
 
 interface RepositoryListProps {
@@ -90,7 +91,7 @@ function RepositoryCard({
 
   // 生成正确编码的Wiki导航URL
   // 使用encodeURIComponent处理特殊字符，确保URL安全
-  const wikiUrl = `/${encodeURIComponent(repo.orgName)}/${encodeURIComponent(repo.repoName)}`;
+  const wikiUrl = buildRepoBasePath(repo.orgName, repo.repoName);
 
   const handleVisibilityChange = (newIsPublic: boolean) => {
     onVisibilityChange(repo.id, newIsPublic);

--- a/web/components/repo/repository-processing-status.tsx
+++ b/web/components/repo/repository-processing-status.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "@/hooks/use-translations";
 import { fetchRepoStatus, fetchProcessingLogs, regenerateRepository } from "@/lib/repository-api";
+import { buildRepoDocPath } from "@/lib/repo-route";
 import type { RepositoryStatus, ProcessingStep, ProcessingLogItem } from "@/types/repository";
 
 // 虚拟化列表项类型
@@ -190,7 +191,7 @@ export function RepositoryProcessingStatus({
         setIsPolling(false);
         setCurrentStep("Complete");
         setTimeout(() => {
-          window.location.href = `/${owner}/${repo}/${statusResponse.defaultSlug}`;
+          window.location.href = buildRepoDocPath(owner, repo, statusResponse.defaultSlug);
         }, 2000);
       }
 

--- a/web/components/repo/repository-submit-form.tsx
+++ b/web/components/repo/repository-submit-form.tsx
@@ -31,16 +31,17 @@ const SUPPORTED_LANGUAGES = [
 ];
 
 function parseGitUrl(url: string): { orgName: string; repoName: string } | null {
-  const httpsMatch = url.match(/https?:\/\/[^/]+\/([^/]+)\/([^/]+?)(?:\.git)?$/i);
+  // Support multi-level paths (e.g. codeup.aliyun.com/org-id/project/repo.git)
+  const httpsMatch = url.match(/https?:\/\/[^/]+\/(.+?)\/([^/]+?)(?:\.git)?$/i);
   if (httpsMatch) {
     return { orgName: httpsMatch[1], repoName: httpsMatch[2] };
   }
-  
-  const sshMatch = url.match(/git@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/i);
+
+  const sshMatch = url.match(/git@[^:]+:(.+?)\/([^/]+?)(?:\.git)?$/i);
   if (sshMatch) {
     return { orgName: sshMatch[1], repoName: sshMatch[2] };
   }
-  
+
   return null;
 }
 

--- a/web/components/repo/source-files.tsx
+++ b/web/components/repo/source-files.tsx
@@ -3,6 +3,7 @@
 import { FileCode2, ExternalLink } from "lucide-react";
 import { useParams, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
+import { decodeRouteSegment } from "@/lib/repo-route";
 
 interface SourceFilesProps {
   files: string[];
@@ -44,8 +45,8 @@ export function SourceFiles({ files, gitUrl, branch }: SourceFilesProps) {
   const searchParams = useSearchParams();
   
   // 从 URL 参数获取仓库信息
-  const owner = params.owner as string;
-  const repo = params.repo as string;
+  const owner = decodeRouteSegment(params.owner as string);
+  const repo = decodeRouteSegment(params.repo as string);
   const currentBranch = searchParams.get("branch") || branch || "main";
   
   // 构建默认的 Git URL

--- a/web/lib/repo-route.ts
+++ b/web/lib/repo-route.ts
@@ -1,0 +1,35 @@
+export function encodePathSegment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+export function decodeRouteSegment(value: string): string {
+  if (!value || !value.includes("%")) {
+    return value;
+  }
+
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export function encodeSlugPath(slug: string): string {
+  return slug
+    .replace(/^[\s/]+|[\s/]+$/g, "")
+    .split("/")
+    .map((segment) => encodePathSegment(segment))
+    .join("/");
+}
+
+export function buildRepoBasePath(owner: string, repo: string): string {
+  return `/${encodePathSegment(owner)}/${encodePathSegment(repo)}`;
+}
+
+export function buildRepoDocPath(owner: string, repo: string, slug: string): string {
+  return `${buildRepoBasePath(owner, repo)}/${encodeSlugPath(slug)}`;
+}
+
+export function buildRepoMindMapPath(owner: string, repo: string): string {
+  return `${buildRepoBasePath(owner, repo)}/mindmap`;
+}


### PR DESCRIPTION
## Background
Repository routes could break when `owner/repo` contains special characters (for example `/`, spaces, or non-ASCII text), because encoding/decoding behavior was inconsistent between frontend and backend.

## What Changed
- Added backend route decoding utility: `RepositoryRouteDecoder`.
- Integrated decoding into backend services:
  - `MindMapApiService`
  - `ProcessingLogApiService`
  - `RepositoryDocsService`
  - `WikiService`
- Added frontend route utility: `web/lib/repo-route.ts` for consistent encode/decode and path building.
- Updated repository-related pages/components to use shared route helpers instead of ad-hoc string building.
- Added unit tests: `RepositoryRouteDecoderUnitTests`.

## Validation
- Added/ran unit tests covering repository route decode behavior.
- Manually verified repository navigation and data loading on:
  - repository home page
  - docs page (including slug routes)
  - mind map page
  - repository entry points from list/card views

## Impact
- Scope is limited to repository URL construction/parsing behavior.
- No database schema or repository business data model changes.

Closes #331
