### PR TITLE
fix(web): fix build errors from broken merge in layout.tsx and api-client.ts

### DIFF
--- a/web/app/[owner]/[repo]/layout.tsx
+++ b/web/app/[owner]/[repo]/layout.tsx
@@ -81,23 +81,28 @@ export default async function RepoLayout({ children, params }: RepoLayoutProps) 
   else {
     // 获取分支和语言数据
     const branches = await getBranchesData(decodedOwner, decodedRepo);
+    const cookieStore = await cookies();
+    const uiLocale = cookieStore.get("NEXT_LOCALE")?.value === "en" ? "en" : "zh";
 
-  // 获取分支和语言数据
-  const branches = await getBranchesData(decodedOwner, decodedRepo);
-  const cookieStore = await cookies();
-  const uiLocale = cookieStore.get("NEXT_LOCALE")?.value === "en" ? "en" : "zh";
+    return (
+      <RepoShell
+        owner={decodedOwner}
+        repo={decodedRepo}
+        initialNodes={tree.nodes}
+        initialBranches={branches ?? undefined}
+        initialBranch={tree.currentBranch}
+        initialLanguage={tree.currentLanguage}
+        uiLocale={uiLocale}
+      >
+        {children}
+      </RepoShell>
+    );
+  }
 
+  // For non-ready states, wrap content in RouteProviders
   return (
-    <RepoShell 
-      owner={decodedOwner} 
-      repo={decodedRepo} 
-      initialNodes={tree.nodes}
-      initialBranches={branches ?? undefined}
-      initialBranch={tree.currentBranch}
-      initialLanguage={tree.currentLanguage}
-      uiLocale={uiLocale}
-    >
-      {children}
-    </RepoShell>
+    <RouteProviders>
+      {content}
+    </RouteProviders>
   );
 }

--- a/web/lib/api-client.ts
+++ b/web/lib/api-client.ts
@@ -107,6 +107,7 @@ export async function apiClient<T>(
 
   if (!response.ok) {
     let errorMessage = "Request failed";
+    let errorData: unknown;
     try {
       const rawError = await response.text();
       if (rawError) {


### PR DESCRIPTION
## Summary
- **`web/app/[owner]/[repo]/layout.tsx`**: Fixes duplicate `branches` variable declaration and unclosed `else` block that caused a Turbopack parse error (`Expected '}', got '<eof>'` at line 103). Non-ready repository states are now properly wrapped in `RouteProviders`.
- **`web/lib/api-client.ts`**: Adds missing `errorData` variable declaration (`let errorData: unknown`) that caused TypeScript compilation failure (`Cannot find name 'errorData'`).

Both issues appear to be merge artifacts from PR #345.

## Test plan
- [ ] `cd web && npm run build` completes without errors
- [ ] Repository pages render correctly for all states (not found, processing, completed, ready)
- [ ] API error responses are properly parsed and displayed