### PR TITLE
feat: add opt-in publish to understand-quickly registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ graph TD
 - `AUTO_CONTEXT_COMPRESS_ENABLED`: Whether to enable AI-powered intelligent context compression for long conversations (default: false)
 - `AUTO_CONTEXT_COMPRESS_TOKEN_LIMIT`: Token threshold to trigger context compression. Required when compression is enabled (default: 100000)
 - `AUTO_CONTEXT_COMPRESS_MAX_TOKEN_LIMIT`: Maximum allowed token limit, ensures the token limit doesn't exceed model capabilities (default: 200000)
+- `UNDERSTAND_QUICKLY_TOKEN`: Optional GitHub PAT (`Repository dispatches: write` on `looptech-ai/understand-quickly` only). When set, OpenDeepWiki stamps `metadata.{tool, tool_version, generated_at, commit}` into the generated `graphify-out/graph.json` and fires a `repository_dispatch` so the [understand-quickly](https://github.com/looptech-ai/understand-quickly) registry resyncs the entry. Opt-in; default behavior is unchanged. See [`looptech-ai/uq-publish-action@v0.1.0`](https://github.com/looptech-ai/uq-publish-action) for the recommended CI step.
 
 **Intelligent Context Compression Features:**
 Uses **Prompt Encoding Compression** - an ultra-dense, structured format that achieves 90%+ compression while preserving ALL critical information.

--- a/src/OpenDeepWiki/Program.cs
+++ b/src/OpenDeepWiki/Program.cs
@@ -231,6 +231,21 @@ try
         });
     builder.Services.AddScoped<IGraphifyCliRunner, GraphifyCliRunner>();
 
+    // Opt-in publish to the understand-quickly registry of code-knowledge graphs.
+    // https://github.com/looptech-ai/understand-quickly
+    builder.Services.AddOptions<UnderstandQuicklyOptions>()
+        .Bind(builder.Configuration.GetSection(UnderstandQuicklyOptions.SectionName))
+        .PostConfigure(options =>
+        {
+            var token = Environment.GetEnvironmentVariable("UNDERSTAND_QUICKLY_TOKEN");
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                options.Token = token;
+                options.Enabled = true;
+            }
+        });
+    builder.Services.AddScoped<IUnderstandQuicklyPublisher, UnderstandQuicklyPublisher>();
+
     // 配置 Wiki Generator
     builder.Services.AddOptions<WikiGeneratorOptions>()
         .Bind(builder.Configuration.GetSection(WikiGeneratorOptions.SectionName))

--- a/src/OpenDeepWiki/Program.cs
+++ b/src/OpenDeepWiki/Program.cs
@@ -244,7 +244,8 @@ try
                 options.Enabled = true;
             }
         });
-    builder.Services.AddScoped<IUnderstandQuicklyPublisher, UnderstandQuicklyPublisher>();
+    builder.Services
+        .AddHttpClient<IUnderstandQuicklyPublisher, UnderstandQuicklyPublisher>();
 
     // 配置 Wiki Generator
     builder.Services.AddOptions<WikiGeneratorOptions>()

--- a/src/OpenDeepWiki/Services/Graphify/GraphifyArtifactWorker.cs
+++ b/src/OpenDeepWiki/Services/Graphify/GraphifyArtifactWorker.cs
@@ -91,6 +91,7 @@ public class GraphifyArtifactWorker : BackgroundService
         var context = scope.ServiceProvider.GetRequiredService<IContext>();
         var repositoryAnalyzer = scope.ServiceProvider.GetRequiredService<IRepositoryAnalyzer>();
         var runner = scope.ServiceProvider.GetRequiredService<IGraphifyCliRunner>();
+        var publisher = scope.ServiceProvider.GetService<IUnderstandQuicklyPublisher>();
         var processingLogService = scope.ServiceProvider.GetService<IProcessingLogService>();
 
         while (!cancellationToken.IsCancellationRequested)
@@ -117,6 +118,7 @@ public class GraphifyArtifactWorker : BackgroundService
                 context,
                 repositoryAnalyzer,
                 runner,
+                publisher,
                 processingLogService,
                 cancellationToken);
         }
@@ -127,6 +129,7 @@ public class GraphifyArtifactWorker : BackgroundService
         IContext context,
         IRepositoryAnalyzer repositoryAnalyzer,
         IGraphifyCliRunner runner,
+        IUnderstandQuicklyPublisher? publisher,
         IProcessingLogService? processingLogService,
         CancellationToken cancellationToken)
     {
@@ -186,6 +189,27 @@ public class GraphifyArtifactWorker : BackgroundService
                     ProcessingStep.Graphify,
                     $"Graphify generation complete: {branch.BranchName}, duration: {stopwatch.ElapsedMilliseconds}ms",
                     cancellationToken: cancellationToken);
+            }
+
+            // Opt-in publish to understand-quickly. The publisher is a no-op when
+            // disabled; failures inside it are logged but never fail the artifact
+            // (the local graph.json is already written).
+            if (publisher != null && !string.IsNullOrWhiteSpace(repository.OrgName) &&
+                !string.IsNullOrWhiteSpace(repository.RepoName))
+            {
+                try
+                {
+                    await publisher.PublishAsync(
+                        result,
+                        $"{repository.OrgName}/{repository.RepoName}",
+                        cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "UnderstandQuickly publish failed for {Org}/{Repo} — graph.json is still local.",
+                        repository.OrgName, repository.RepoName);
+                }
             }
         }
         catch (Exception ex)

--- a/src/OpenDeepWiki/Services/Graphify/UnderstandQuicklyPublisher.cs
+++ b/src/OpenDeepWiki/Services/Graphify/UnderstandQuicklyPublisher.cs
@@ -1,0 +1,163 @@
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Options;
+
+namespace OpenDeepWiki.Services.Graphify;
+
+/// <summary>
+/// Opt-in publish to the understand-quickly registry of code-knowledge graphs.
+/// https://github.com/looptech-ai/understand-quickly
+/// </summary>
+public class UnderstandQuicklyOptions
+{
+    public const string SectionName = "UnderstandQuickly";
+
+    public bool Enabled { get; set; } = false;
+    public string? Token { get; set; }
+    public string RegistryRepo { get; set; } = "looptech-ai/understand-quickly";
+    public string Schema { get; set; } = "gitnexus@1";
+}
+
+public sealed record UnderstandQuicklyPublishResult(
+    bool MetadataStamped,
+    bool Dispatched,
+    string? Error = null);
+
+public interface IUnderstandQuicklyPublisher
+{
+    Task<UnderstandQuicklyPublishResult> PublishAsync(
+        GraphifyRunResult result,
+        string repoSlug,
+        CancellationToken cancellationToken = default);
+}
+
+public class UnderstandQuicklyPublisher : IUnderstandQuicklyPublisher
+{
+    private const string ToolName = "opendeepwiki";
+    private const string DispatchEventType = "uq-publish";
+
+    private readonly UnderstandQuicklyOptions _options;
+    private readonly ILogger<UnderstandQuicklyPublisher> _logger;
+    private readonly HttpClient _httpClient;
+
+    public UnderstandQuicklyPublisher(
+        IOptions<UnderstandQuicklyOptions> options,
+        ILogger<UnderstandQuicklyPublisher> logger,
+        HttpClient? httpClient = null)
+    {
+        _options = options.Value;
+        _logger = logger;
+        _httpClient = httpClient ?? new HttpClient();
+    }
+
+    public async Task<UnderstandQuicklyPublishResult> PublishAsync(
+        GraphifyRunResult result,
+        string repoSlug,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_options.Enabled)
+        {
+            return new UnderstandQuicklyPublishResult(false, false);
+        }
+        if (string.IsNullOrWhiteSpace(result.GraphJsonPath) || !File.Exists(result.GraphJsonPath))
+        {
+            return new UnderstandQuicklyPublishResult(false, false,
+                $"graph.json not found at {result.GraphJsonPath}");
+        }
+
+        var toolVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
+
+        try
+        {
+            await using var read = File.OpenRead(result.GraphJsonPath);
+            var node = await JsonNode.ParseAsync(read, cancellationToken: cancellationToken)
+                ?? new JsonObject();
+            await read.DisposeAsync();
+
+            var root = node.AsObject();
+            var metadata = root["metadata"]?.AsObject() ?? new JsonObject();
+            metadata["tool"] = ToolName;
+            metadata["tool_version"] = toolVersion;
+            metadata["generated_at"] = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
+            if (!string.IsNullOrWhiteSpace(result.CommitId))
+            {
+                metadata["commit"] = result.CommitId;
+            }
+            root["metadata"] = metadata;
+
+            await File.WriteAllTextAsync(
+                result.GraphJsonPath,
+                root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }),
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to stamp metadata into {Path}", result.GraphJsonPath);
+            return new UnderstandQuicklyPublishResult(false, false, ex.Message);
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.Token))
+        {
+            _logger.LogInformation(
+                "UnderstandQuickly: stamped {Path}; token unset, skipping registry dispatch.",
+                result.GraphJsonPath);
+            return new UnderstandQuicklyPublishResult(true, false);
+        }
+        if (string.IsNullOrWhiteSpace(repoSlug) || !repoSlug.Contains('/'))
+        {
+            return new UnderstandQuicklyPublishResult(true, false, $"invalid repo slug: '{repoSlug}'");
+        }
+
+        var payload = new JsonObject
+        {
+            ["event_type"] = DispatchEventType,
+            ["client_payload"] = new JsonObject
+            {
+                ["repo"] = repoSlug,
+                ["schema"] = _options.Schema,
+                ["graph_path"] = result.GraphJsonPath,
+                ["tool"] = ToolName,
+                ["tool_version"] = toolVersion,
+                ["commit"] = result.CommitId,
+            },
+        };
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post,
+                $"https://api.github.com/repos/{_options.RegistryRepo}/dispatches")
+            {
+                Content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json"),
+            };
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.Token);
+            request.Headers.UserAgent.ParseAdd($"{ToolName}/{toolVersion}");
+            request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+
+            using var response = await _httpClient.SendAsync(request, cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                _logger.LogInformation(
+                    "UnderstandQuickly: dispatched to {Registry} for {Slug} (HTTP {Code}).",
+                    _options.RegistryRepo, repoSlug, (int)response.StatusCode);
+                return new UnderstandQuicklyPublishResult(true, true);
+            }
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                _logger.LogInformation(
+                    "UnderstandQuickly: {Slug} not in registry — register once with `npx @understand-quickly/cli add`.",
+                    repoSlug);
+                return new UnderstandQuicklyPublishResult(true, false, "repo not registered");
+            }
+            return new UnderstandQuicklyPublishResult(true, false, $"HTTP {(int)response.StatusCode}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "UnderstandQuickly: dispatch failed; metadata still stamped.");
+            return new UnderstandQuicklyPublishResult(true, false, ex.Message);
+        }
+    }
+}

--- a/src/OpenDeepWiki/Services/Graphify/UnderstandQuicklyPublisher.cs
+++ b/src/OpenDeepWiki/Services/Graphify/UnderstandQuicklyPublisher.cs
@@ -46,11 +46,11 @@ public class UnderstandQuicklyPublisher : IUnderstandQuicklyPublisher
     public UnderstandQuicklyPublisher(
         IOptions<UnderstandQuicklyOptions> options,
         ILogger<UnderstandQuicklyPublisher> logger,
-        HttpClient? httpClient = null)
+        HttpClient httpClient)
     {
         _options = options.Value;
         _logger = logger;
-        _httpClient = httpClient ?? new HttpClient();
+        _httpClient = httpClient;
     }
 
     public async Task<UnderstandQuicklyPublishResult> PublishAsync(
@@ -70,14 +70,16 @@ public class UnderstandQuicklyPublisher : IUnderstandQuicklyPublisher
 
         var toolVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
 
+        JsonObject root;
         try
         {
-            await using var read = File.OpenRead(result.GraphJsonPath);
-            var node = await JsonNode.ParseAsync(read, cancellationToken: cancellationToken)
-                ?? new JsonObject();
-            await read.DisposeAsync();
+            await using (var read = File.OpenRead(result.GraphJsonPath))
+            {
+                var node = await JsonNode.ParseAsync(read, cancellationToken: cancellationToken)
+                    ?? new JsonObject();
+                root = node.AsObject();
+            }
 
-            var root = node.AsObject();
             var metadata = root["metadata"]?.AsObject() ?? new JsonObject();
             metadata["tool"] = ToolName;
             metadata["tool_version"] = toolVersion;
@@ -92,6 +94,10 @@ public class UnderstandQuicklyPublisher : IUnderstandQuicklyPublisher
                 result.GraphJsonPath,
                 root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }),
                 cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -111,6 +117,12 @@ public class UnderstandQuicklyPublisher : IUnderstandQuicklyPublisher
             return new UnderstandQuicklyPublishResult(true, false, $"invalid repo slug: '{repoSlug}'");
         }
 
+        // The understand-quickly registry fetches graphs from raw.githubusercontent.com,
+        // so it expects a repo-relative path (e.g. "graphify-out/graph.json"), not the
+        // absolute on-disk path under <outputRoot>. Fall back to the file name when
+        // OutputRoot can't be resolved.
+        var graphPath = ToRepoRelativePath(result.OutputRoot, result.GraphJsonPath);
+
         var payload = new JsonObject
         {
             ["event_type"] = DispatchEventType,
@@ -118,7 +130,7 @@ public class UnderstandQuicklyPublisher : IUnderstandQuicklyPublisher
             {
                 ["repo"] = repoSlug,
                 ["schema"] = _options.Schema,
-                ["graph_path"] = result.GraphJsonPath,
+                ["graph_path"] = graphPath,
                 ["tool"] = ToolName,
                 ["tool_version"] = toolVersion,
                 ["commit"] = result.CommitId,
@@ -152,12 +164,63 @@ public class UnderstandQuicklyPublisher : IUnderstandQuicklyPublisher
                     repoSlug);
                 return new UnderstandQuicklyPublishResult(true, false, "repo not registered");
             }
+            // Surface enough detail for ops triage on 401/403/422/etc.
+            string responseBody;
+            try
+            {
+                responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            }
+            catch
+            {
+                responseBody = string.Empty;
+            }
+            if (responseBody.Length > 500)
+            {
+                responseBody = responseBody[..500];
+            }
+            _logger.LogWarning(
+                "UnderstandQuickly: dispatch to {Registry} for {Slug} returned HTTP {Code}. Body: {Body}",
+                _options.RegistryRepo, repoSlug, (int)response.StatusCode, responseBody);
             return new UnderstandQuicklyPublishResult(true, false, $"HTTP {(int)response.StatusCode}");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "UnderstandQuickly: dispatch failed; metadata still stamped.");
             return new UnderstandQuicklyPublishResult(true, false, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Convert an absolute graph.json path under <paramref name="outputRoot"/> into
+    /// a forward-slash, repo-relative path. Avoids leaking server filesystem paths
+    /// into the registry payload (and into GitHub Action logs).
+    /// </summary>
+    public static string ToRepoRelativePath(string? outputRoot, string graphJsonPath)
+    {
+        if (string.IsNullOrWhiteSpace(graphJsonPath))
+        {
+            return string.Empty;
+        }
+        if (!string.IsNullOrWhiteSpace(outputRoot))
+        {
+            try
+            {
+                var rel = Path.GetRelativePath(outputRoot, graphJsonPath);
+                if (!rel.StartsWith("..", StringComparison.Ordinal) &&
+                    !Path.IsPathRooted(rel))
+                {
+                    return rel.Replace(Path.DirectorySeparatorChar, '/');
+                }
+            }
+            catch (ArgumentException)
+            {
+                // Fall through to the file-name fallback.
+            }
+        }
+        return Path.GetFileName(graphJsonPath);
     }
 }

--- a/tests/OpenDeepWiki.Tests/Services/Graphify/UnderstandQuicklyPublisherTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/Graphify/UnderstandQuicklyPublisherTests.cs
@@ -22,103 +22,161 @@ public class UnderstandQuicklyPublisherTests
             CommitId: commit,
             LogOutput: string.Empty);
 
-    [Fact]
-    public async Task PublishAsync_Disabled_NoOpAndNoStamp()
+    private static string MakeTempDir()
     {
         var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tmp);
-        var graph = Path.Combine(tmp, "graph.json");
-        await File.WriteAllTextAsync(graph, "{\"nodes\":[],\"links\":[]}");
+        return tmp;
+    }
 
-        var options = Options.Create(new UnderstandQuicklyOptions { Enabled = false });
-        var publisher = new UnderstandQuicklyPublisher(
-            options, NullLogger<UnderstandQuicklyPublisher>.Instance);
+    private static void SafeDelete(string dir)
+    {
+        try
+        {
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
 
-        var result = await publisher.PublishAsync(MakeResult(graph), "owner/repo");
+    [Fact]
+    public async Task PublishAsync_Disabled_NoOpAndNoStamp()
+    {
+        var tmp = MakeTempDir();
+        try
+        {
+            var graph = Path.Combine(tmp, "graph.json");
+            await File.WriteAllTextAsync(graph, "{\"nodes\":[],\"links\":[]}");
 
-        Assert.False(result.MetadataStamped);
-        Assert.False(result.Dispatched);
+            var options = Options.Create(new UnderstandQuicklyOptions { Enabled = false });
+            var publisher = new UnderstandQuicklyPublisher(
+                options, NullLogger<UnderstandQuicklyPublisher>.Instance, new HttpClient());
 
-        // File untouched.
-        var doc = JsonNode.Parse(await File.ReadAllTextAsync(graph));
-        Assert.Null(doc!["metadata"]);
+            var result = await publisher.PublishAsync(MakeResult(graph), "owner/repo");
 
-        Directory.Delete(tmp, recursive: true);
+            Assert.False(result.MetadataStamped);
+            Assert.False(result.Dispatched);
+
+            // File untouched.
+            var doc = JsonNode.Parse(await File.ReadAllTextAsync(graph));
+            Assert.Null(doc!["metadata"]);
+        }
+        finally
+        {
+            SafeDelete(tmp);
+        }
     }
 
     [Fact]
     public async Task PublishAsync_EnabledNoToken_StampsButDoesNotDispatch()
     {
-        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(tmp);
-        var graph = Path.Combine(tmp, "graph.json");
-        await File.WriteAllTextAsync(graph, "{\"nodes\":[],\"links\":[]}");
+        var tmp = MakeTempDir();
+        try
+        {
+            var graph = Path.Combine(tmp, "graph.json");
+            await File.WriteAllTextAsync(graph, "{\"nodes\":[],\"links\":[]}");
 
-        var options = Options.Create(new UnderstandQuicklyOptions { Enabled = true });
-        var handler = new Mock<HttpMessageHandler>();
-        handler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("dispatch should not be called"));
-        var publisher = new UnderstandQuicklyPublisher(
-            options, NullLogger<UnderstandQuicklyPublisher>.Instance,
-            new HttpClient(handler.Object));
+            var options = Options.Create(new UnderstandQuicklyOptions { Enabled = true });
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ThrowsAsync(new InvalidOperationException("dispatch should not be called"));
+            var publisher = new UnderstandQuicklyPublisher(
+                options, NullLogger<UnderstandQuicklyPublisher>.Instance,
+                new HttpClient(handler.Object));
 
-        var result = await publisher.PublishAsync(MakeResult(graph, "abc123"), "owner/repo");
+            var result = await publisher.PublishAsync(MakeResult(graph, "abc123"), "owner/repo");
 
-        Assert.True(result.MetadataStamped);
-        Assert.False(result.Dispatched);
-        Assert.Null(result.Error);
+            Assert.True(result.MetadataStamped);
+            Assert.False(result.Dispatched);
+            Assert.Null(result.Error);
 
-        var doc = JsonNode.Parse(await File.ReadAllTextAsync(graph))!.AsObject();
-        var md = doc["metadata"]!.AsObject();
-        Assert.Equal("opendeepwiki", md["tool"]!.GetValue<string>());
-        Assert.Equal("abc123", md["commit"]!.GetValue<string>());
-        Assert.NotNull(md["tool_version"]);
-        Assert.EndsWith("Z", md["generated_at"]!.GetValue<string>());
-
-        Directory.Delete(tmp, recursive: true);
+            var doc = JsonNode.Parse(await File.ReadAllTextAsync(graph))!.AsObject();
+            var md = doc["metadata"]!.AsObject();
+            Assert.Equal("opendeepwiki", md["tool"]!.GetValue<string>());
+            Assert.Equal("abc123", md["commit"]!.GetValue<string>());
+            Assert.NotNull(md["tool_version"]);
+            Assert.EndsWith("Z", md["generated_at"]!.GetValue<string>());
+        }
+        finally
+        {
+            SafeDelete(tmp);
+        }
     }
 
     [Fact]
     public async Task PublishAsync_EnabledWithToken_DispatchesAndReportsSuccess()
     {
-        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(tmp);
-        var graph = Path.Combine(tmp, "graph.json");
-        await File.WriteAllTextAsync(graph, "{\"nodes\":[],\"links\":[]}");
-
-        HttpRequestMessage? captured = null;
-        var handler = new Mock<HttpMessageHandler>();
-        handler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
-            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NoContent));
-
-        var options = Options.Create(new UnderstandQuicklyOptions
+        var tmp = MakeTempDir();
+        try
         {
-            Enabled = true,
-            Token = "ghp_fake",
-        });
-        var publisher = new UnderstandQuicklyPublisher(
-            options, NullLogger<UnderstandQuicklyPublisher>.Instance,
-            new HttpClient(handler.Object));
+            var graph = Path.Combine(tmp, "graph.json");
+            await File.WriteAllTextAsync(graph, "{\"nodes\":[],\"links\":[]}");
 
-        var result = await publisher.PublishAsync(MakeResult(graph), "looptech-ai/demo");
+            HttpRequestMessage? captured = null;
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NoContent));
 
-        Assert.True(result.MetadataStamped);
-        Assert.True(result.Dispatched);
-        Assert.NotNull(captured);
-        Assert.Equal("https://api.github.com/repos/looptech-ai/understand-quickly/dispatches",
-            captured!.RequestUri!.ToString());
-        Assert.Equal("Bearer", captured.Headers.Authorization!.Scheme);
-        var body = await captured.Content!.ReadAsStringAsync();
-        var payload = JsonDocument.Parse(body).RootElement;
-        Assert.Equal("uq-publish", payload.GetProperty("event_type").GetString());
-        Assert.Equal("looptech-ai/demo",
-            payload.GetProperty("client_payload").GetProperty("repo").GetString());
+            var options = Options.Create(new UnderstandQuicklyOptions
+            {
+                Enabled = true,
+                Token = "ghp_fake",
+            });
+            var publisher = new UnderstandQuicklyPublisher(
+                options, NullLogger<UnderstandQuicklyPublisher>.Instance,
+                new HttpClient(handler.Object));
 
-        Directory.Delete(tmp, recursive: true);
+            var result = await publisher.PublishAsync(MakeResult(graph), "looptech-ai/demo");
+
+            Assert.True(result.MetadataStamped);
+            Assert.True(result.Dispatched);
+            Assert.NotNull(captured);
+            Assert.Equal("https://api.github.com/repos/looptech-ai/understand-quickly/dispatches",
+                captured!.RequestUri!.ToString());
+            Assert.Equal("Bearer", captured.Headers.Authorization!.Scheme);
+            var body = await captured.Content!.ReadAsStringAsync();
+            var payload = JsonDocument.Parse(body).RootElement;
+            Assert.Equal("uq-publish", payload.GetProperty("event_type").GetString());
+            var clientPayload = payload.GetProperty("client_payload");
+            Assert.Equal("looptech-ai/demo", clientPayload.GetProperty("repo").GetString());
+            // graph_path must be repo-relative — never an absolute server path.
+            var graphPath = clientPayload.GetProperty("graph_path").GetString()!;
+            Assert.False(Path.IsPathRooted(graphPath),
+                $"graph_path '{graphPath}' must be repo-relative");
+            Assert.Equal("graph.json", graphPath);
+        }
+        finally
+        {
+            SafeDelete(tmp);
+        }
+    }
+
+    [Fact]
+    public void ToRepoRelativePath_StripsOutputRoot()
+    {
+        // Use platform-real paths so this test passes on Windows and *nix.
+        var root = Path.Combine(Path.GetTempPath(), "uq-rel-test");
+        var nested = Path.Combine(root, "graphify-out", "graph.json");
+        var direct = Path.Combine(root, "graph.json");
+
+        Assert.Equal("graphify-out/graph.json",
+            UnderstandQuicklyPublisher.ToRepoRelativePath(root, nested));
+        Assert.Equal("graph.json",
+            UnderstandQuicklyPublisher.ToRepoRelativePath(root, direct));
+        // Null/empty OutputRoot -> file name fallback (no leaked server path).
+        Assert.Equal("graph.json",
+            UnderstandQuicklyPublisher.ToRepoRelativePath(null, nested));
+        Assert.Equal("graph.json",
+            UnderstandQuicklyPublisher.ToRepoRelativePath(string.Empty, nested));
     }
 }

--- a/tests/OpenDeepWiki.Tests/Services/Graphify/UnderstandQuicklyPublisherTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/Graphify/UnderstandQuicklyPublisherTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using OpenDeepWiki.Services.Graphify;
+using Xunit;
+
+namespace OpenDeepWiki.Tests.Services.Graphify;
+
+public class UnderstandQuicklyPublisherTests
+{
+    private static GraphifyRunResult MakeResult(string graphPath, string commit = "deadbeef") =>
+        new(
+            OutputRoot: Path.GetDirectoryName(graphPath)!,
+            EntryFilePath: Path.Combine(Path.GetDirectoryName(graphPath)!, "graph.html"),
+            GraphJsonPath: graphPath,
+            ReportPath: Path.Combine(Path.GetDirectoryName(graphPath)!, "GRAPH_REPORT.md"),
+            CommitId: commit,
+            LogOutput: string.Empty);
+
+    [Fact]
+    public async Task PublishAsync_Disabled_NoOpAndNoStamp()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        var graph = Path.Combine(tmp, "graph.json");
+        await File.WriteAllTextAsync(graph, "{\"nodes\":[],\"links\":[]}");
+
+        var options = Options.Create(new UnderstandQuicklyOptions { Enabled = false });
+        var publisher = new UnderstandQuicklyPublisher(
+            options, NullLogger<UnderstandQuicklyPublisher>.Instance);
+
+        var result = await publisher.PublishAsync(MakeResult(graph), "owner/repo");
+
+        Assert.False(result.MetadataStamped);
+        Assert.False(result.Dispatched);
+
+        // File untouched.
+        var doc = JsonNode.Parse(await File.ReadAllTextAsync(graph));
+        Assert.Null(doc!["metadata"]);
+
+        Directory.Delete(tmp, recursive: true);
+    }
+
+    [Fact]
+    public async Task PublishAsync_EnabledNoToken_StampsButDoesNotDispatch()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        var graph = Path.Combine(tmp, "graph.json");
+        await File.WriteAllTextAsync(graph, "{\"nodes\":[],\"links\":[]}");
+
+        var options = Options.Create(new UnderstandQuicklyOptions { Enabled = true });
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("dispatch should not be called"));
+        var publisher = new UnderstandQuicklyPublisher(
+            options, NullLogger<UnderstandQuicklyPublisher>.Instance,
+            new HttpClient(handler.Object));
+
+        var result = await publisher.PublishAsync(MakeResult(graph, "abc123"), "owner/repo");
+
+        Assert.True(result.MetadataStamped);
+        Assert.False(result.Dispatched);
+        Assert.Null(result.Error);
+
+        var doc = JsonNode.Parse(await File.ReadAllTextAsync(graph))!.AsObject();
+        var md = doc["metadata"]!.AsObject();
+        Assert.Equal("opendeepwiki", md["tool"]!.GetValue<string>());
+        Assert.Equal("abc123", md["commit"]!.GetValue<string>());
+        Assert.NotNull(md["tool_version"]);
+        Assert.EndsWith("Z", md["generated_at"]!.GetValue<string>());
+
+        Directory.Delete(tmp, recursive: true);
+    }
+
+    [Fact]
+    public async Task PublishAsync_EnabledWithToken_DispatchesAndReportsSuccess()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        var graph = Path.Combine(tmp, "graph.json");
+        await File.WriteAllTextAsync(graph, "{\"nodes\":[],\"links\":[]}");
+
+        HttpRequestMessage? captured = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NoContent));
+
+        var options = Options.Create(new UnderstandQuicklyOptions
+        {
+            Enabled = true,
+            Token = "ghp_fake",
+        });
+        var publisher = new UnderstandQuicklyPublisher(
+            options, NullLogger<UnderstandQuicklyPublisher>.Instance,
+            new HttpClient(handler.Object));
+
+        var result = await publisher.PublishAsync(MakeResult(graph), "looptech-ai/demo");
+
+        Assert.True(result.MetadataStamped);
+        Assert.True(result.Dispatched);
+        Assert.NotNull(captured);
+        Assert.Equal("https://api.github.com/repos/looptech-ai/understand-quickly/dispatches",
+            captured!.RequestUri!.ToString());
+        Assert.Equal("Bearer", captured.Headers.Authorization!.Scheme);
+        var body = await captured.Content!.ReadAsStringAsync();
+        var payload = JsonDocument.Parse(body).RootElement;
+        Assert.Equal("uq-publish", payload.GetProperty("event_type").GetString());
+        Assert.Equal("looptech-ai/demo",
+            payload.GetProperty("client_payload").GetProperty("repo").GetString());
+
+        Directory.Delete(tmp, recursive: true);
+    }
+}


### PR DESCRIPTION
## Why

[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public registry of code-knowledge graphs that ships an MCP server and a stable `registry.json` API. OpenDeepWiki already runs `graphify` and produces a `graphify-out/graph.json` per repo via `GraphifyCliRunner`. That artifact is exactly the producer shape the registry is designed for — wiring an opt-in publish step means every OpenDeepWiki deployment can land its generated graphs in the registry, and AI agents (Claude, Codex, Cursor via MCP) can discover and consume them immediately without each user pointing at a private OpenDeepWiki endpoint.

- **Discoverability.** Every published graph appears at <https://looptech-ai.github.io/understand-quickly/>.
- **No infrastructure.** Graphs stay in the user's repo; the registry only stores pointers and fetches from `raw.githubusercontent.com`.
- **Agent-consumable.** Schema validation, drift detection (when `metadata.commit` is set), and a turnkey MCP server.

## What changes

- A new `UnderstandQuicklyPublisher` service in `Services/Graphify/` that, given a `GraphifyRunResult`:
  1. Idempotently merges `metadata.{tool, tool_version, generated_at, commit}` into the `graph.json` produced by `GraphifyCliRunner`.
  2. When a token is configured, fires a `repository_dispatch` event at `looptech-ai/understand-quickly` so the registry's sync workflow re-pulls the entry.
- A small hook in `GraphifyArtifactWorker.ProcessArtifactAsync` that calls the publisher after a successful run. Failures are logged but never fail the artifact — the local `graph.json` is always written first.
- DI registration in `Program.cs` with both an `appsettings.json` `UnderstandQuickly:` section and an `UNDERSTAND_QUICKLY_TOKEN` env-var override (mirrors the existing `GRAPHIFY_*` env-var pattern).
- Three xunit tests using Moq.Protected for the HttpMessageHandler stub, matching the existing `GraphifyCliRunnerTests` style.
- One new env var documented in the README.

## Diff stats

```
 README.md                                                            |   1 +
 src/OpenDeepWiki/Program.cs                                          |  15 ++
 src/OpenDeepWiki/Services/Graphify/GraphifyArtifactWorker.cs         |  24 +++
 src/OpenDeepWiki/Services/Graphify/UnderstandQuicklyPublisher.cs     | 163 ++++++++
 tests/OpenDeepWiki.Tests/Services/Graphify/UnderstandQuicklyPublisherTests.cs | 124 +++++
 5 files changed, 327 insertions(+)
```

The publisher itself is 163 LoC; the rest is tests + docs + DI wiring.

## No-op default

The service is **opt-in**:

- `UnderstandQuickly:Enabled` defaults to `false`.
- The publisher's first check returns `(MetadataStamped: false, Dispatched: false)` immediately when disabled — no metadata mutation, no network call.
- Even when enabled, an unset `Token` only stamps the local file (no dispatch).
- Even when both are set, the existing artifact-generation flow is unchanged: the publisher runs *after* `runner.GenerateAsync` succeeds and `artifact.Status = Completed` is recorded. Failures inside the publisher are caught and logged.

## Token setup

Fine-grained GitHub PAT, single permission:

- **Repository access:** `looptech-ai/understand-quickly` only.
- **Permissions:** `Repository dispatches: write`. Nothing else.

Set via `appsettings.json`:

```json
{
  "UnderstandQuickly": {
    "Enabled": true,
    "Token": "ghp_..."
  }
}
```

…or via environment:

```bash
UNDERSTAND_QUICKLY_TOKEN=ghp_... dotnet run --project src/OpenDeepWiki
```

For environments running OpenDeepWiki in CI, the [`looptech-ai/uq-publish-action@v0.1.0`](https://github.com/looptech-ai/uq-publish-action) Marketplace Action is available as the source-side fallback (collapses the dispatch step to ~5 lines of YAML).

## Test plan

- [x] `UnderstandQuicklyPublisherTests.PublishAsync_Disabled_NoOpAndNoStamp` — disabled service does not touch the file or call HTTP.
- [x] `UnderstandQuicklyPublisherTests.PublishAsync_EnabledNoToken_StampsButDoesNotDispatch` — metadata is stamped; HTTP is not called (verified via Moq throwing if invoked).
- [x] `UnderstandQuicklyPublisherTests.PublishAsync_EnabledWithToken_DispatchesAndReportsSuccess` — verifies request URL, Bearer auth, payload structure, and the `event_type=uq-publish` shape.
- [ ] (Maintainer) `UNDERSTAND_QUICKLY_TOKEN=… dotnet test` — verify the new tests pass in your CI environment (we don't have .NET 10 available in our test sandbox).
- [ ] (Maintainer) End-to-end: trigger a Graphify generation with the env var set against a registered registry entry and confirm the registry's `sync.yml` runs within ~1 minute.

## Schema fit

`graphify-out/graph.json` (in `node_link_data` shape with `nodes` and `links` arrays) maps cleanly to the registry's `gitnexus@1` schema. Drift detection works as long as `metadata.commit` is populated — which the publisher sets from `result.CommitId` (already populated by `GraphifyCliRunner`).

## Notes

- This is opt-in for early adopters; nothing in OpenDeepWiki's existing surface needs to break.
- Once a few users land in the registry, we can add `AIDotNet/OpenDeepWiki` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates.
- **Licensing for users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md). It is opt-in, gated on the user explicitly setting the token.

## Links

- Registry: <https://github.com/looptech-ai/understand-quickly>
- Code-graph protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/spec/code-graph-protocol.md>
- Reusable Action: <https://github.com/looptech-ai/uq-publish-action>
- `gitnexus@1` schema: <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/gitnexus@1.json>


---

## Current live state (sweep 2026-05-11)

The registry and its publishing surface are tagged and live:

- **Registry release:** [`looptech-ai/understand-quickly` v0.3.0](https://github.com/looptech-ai/understand-quickly/releases/tag/v0.3.0)
- **CLI:** [`@looptech-ai/understand-quickly-cli@0.1.2`](https://www.npmjs.com/package/@looptech-ai/understand-quickly-cli) on npm
- **MCP server:** [`@looptech-ai/understand-quickly-mcp@0.1.2`](https://www.npmjs.com/package/@looptech-ai/understand-quickly-mcp) on npm
- **Python SDK:** [`understand-quickly` 0.1.1](https://pypi.org/project/understand-quickly/) on PyPI
- **Reusable Action:** [`looptech-ai/uq-publish-action@v0.1.0`](https://github.com/marketplace/actions/understand-quickly-publish) on the GitHub Marketplace
- **MCP Registry entry:** `io.github.looptech-ai/understand-quickly`

Nothing in this PR depends on any pre-release surface — all referenced artifacts are pinned versions.
