### PR TITLE
fix: support multipart/form-data for ZIP archive upload

### DIFF
--- a/src/OpenDeepWiki/Endpoints/RepositoryUploadEndpoints.cs
+++ b/src/OpenDeepWiki/Endpoints/RepositoryUploadEndpoints.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Mvc;
+using OpenDeepWiki.Models;
+using OpenDeepWiki.Services.Repositories;
+
+namespace OpenDeepWiki.Endpoints;
+
+/// <summary>
+/// Hand-written multipart endpoints for repository uploads.
+/// The MiniApi source generator does not preserve the [FromForm] binding, so the generated
+/// /submit-archive endpoint is registered as a JSON body and rejects multipart/form-data with 415.
+/// This endpoint reads the multipart form explicitly and delegates to the existing service logic.
+/// </summary>
+public static class RepositoryUploadEndpoints
+{
+    public static IEndpointRouteBuilder MapRepositoryUploadEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/v1/repositories/submit-archive", SubmitArchiveAsync)
+            .WithTags("仓库")
+            .WithName("SubmitArchiveRepository")
+            .WithSummary("通过 ZIP 压缩包创建仓库")
+            .DisableAntiforgery();
+
+        return app;
+    }
+
+    private static async Task<IResult> SubmitArchiveAsync(
+        HttpRequest httpRequest,
+        [FromServices] RepositoryService repositoryService)
+    {
+        if (!httpRequest.HasFormContentType)
+        {
+            return Results.BadRequest(new { message = "请使用 multipart/form-data 格式上传" });
+        }
+
+        var form = await httpRequest.ReadFormAsync();
+        var archive = form.Files["archive"];
+
+        var branchName = form["branchName"].ToString();
+        var request = new ArchiveRepositorySubmitRequest
+        {
+            OrgName = form["orgName"].ToString(),
+            RepoName = form["repoName"].ToString(),
+            BranchName = string.IsNullOrWhiteSpace(branchName) ? "main" : branchName,
+            LanguageCode = form["languageCode"].ToString(),
+            IsPublic = bool.TryParse(form["isPublic"], out var isPublic) && isPublic,
+            GenerateSkill = bool.TryParse(form["generateSkill"], out var generateSkill) && generateSkill,
+            Archive = archive,
+        };
+
+        var repository = await repositoryService.SubmitArchiveAsync(request);
+        return Results.Ok(repository);
+    }
+}

--- a/src/OpenDeepWiki/Program.cs
+++ b/src/OpenDeepWiki/Program.cs
@@ -383,6 +383,7 @@ try
     }
 
     app.MapMiniApis();
+    app.MapRepositoryUploadEndpoints();
     app.MapAuthEndpoints();
     app.MapApiKeyEndpoints();
     app.MapOAuthEndpoints();

--- a/src/OpenDeepWiki/Services/Repositories/RepositoryService.cs
+++ b/src/OpenDeepWiki/Services/Repositories/RepositoryService.cs
@@ -83,8 +83,10 @@ public class RepositoryService(
             forkCount);
     }
 
-    [HttpPost("/submit-archive")]
-    public async Task<Repository> SubmitArchiveAsync([FromForm] ArchiveRepositorySubmitRequest request)
+    // Mapped manually in RepositoryUploadEndpoints: the MiniApi source generator drops the
+    // [FromForm] binding and treats the request as a JSON body, which makes multipart uploads
+    // fail with 415. Keeping this method attribute-free excludes it from the generated mapping.
+    public async Task<Repository> SubmitArchiveAsync(ArchiveRepositorySubmitRequest request)
     {
         var currentUserId = GetCurrentUserId();
 


### PR DESCRIPTION
### Problem

Uploading a repository as a ZIP archive fails with **HTTP 415 Unsupported Media Type**.

The MiniApi source generator does not preserve the `[FromForm]` binding on `RepositoryService.SubmitArchiveAsync`, so the generated `/submit-archive` endpoint is registered as a JSON body and rejects `multipart/form-data` requests.

### Fix

- Remove `[HttpPost]` / `[FromForm]` from `RepositoryService.SubmitArchiveAsync` so it is excluded from the generated mapping and kept as a plain service method.
- Add `RepositoryUploadEndpoints` that maps `POST /api/v1/repositories/submit-archive` by hand, reads the multipart form explicitly via `ReadFormAsync` and calls `DisableAntiforgery()`.
- Register the new endpoint in `Program.cs`.

### Testing

Verified that a ZIP upload via `multipart/form-data` now returns **200** and creates the repository, instead of failing with 415.
