### PR TITLE
当文档生成过程中有部分文档失败时（54个文档中17个失败），代码会抛出 `InvalidOperationException` ，导致整个…

### DIFF
--- a/src/OpenDeepWiki/Services/Wiki/WikiGeneratorOptions.cs
+++ b/src/OpenDeepWiki/Services/Wiki/WikiGeneratorOptions.cs
@@ -144,4 +144,10 @@ public class WikiGeneratorOptions
     {
         return string.IsNullOrWhiteSpace(TranslationModel) ? ContentModel : TranslationModel;
     }
+    /// <summary>
+    /// Whether to throw an exception when some documents fail to generate.
+    /// When set to false, the generator will log warnings but continue processing.
+    /// Default: false (continue on partial failure)
+    /// </summary>
+    public bool ThrowOnPartialFailure { get; set; } = false;
 }


### PR DESCRIPTION
…仓库处理失败。

- `WikiGeneratorOptions.cs`  - 添加一个配置选项来控制是否在部分失败时抛出异常
- `WikiGenerator.cs` - 修改 `GenerateDocumentsAsync`  方法，根据配置决定是否抛出异常