### PR TITLE
Prevent incremental updates from wiping the wiki catalog

### DIFF
--- a/src/OpenDeepWiki/Services/Wiki/CatalogStorage.cs
+++ b/src/OpenDeepWiki/Services/Wiki/CatalogStorage.cs
@@ -70,6 +70,16 @@ public class CatalogStorage
             .Where(c => c.BranchLanguageId == _branchLanguageId && !c.IsDeleted)
             .ToListAsync(cancellationToken);
 
+        // Refuse a destructive replacement: a populated catalog must not shrink drastically.
+        // A partial-view agent run must use EditCatalog instead of rewriting everything.
+        static int CountItems(List<CatalogItem> items) => items.Sum(i => 1 + CountItems(i.Children));
+        var newCount = CountItems(root.Items);
+        if (existingCatalogs.Count >= 10 && newCount < existingCatalogs.Count / 2)
+        {
+            throw new InvalidOperationException(
+                $"Refusing to replace catalog: new structure has {newCount} items but {existingCatalogs.Count} exist. Use EditCatalog for partial updates.");
+        }
+
         foreach (var catalog in existingCatalogs)
         {
             catalog.MarkAsDeleted();

--- a/src/OpenDeepWiki/Services/Wiki/WikiGenerator.cs
+++ b/src/OpenDeepWiki/Services/Wiki/WikiGenerator.cs
@@ -655,8 +655,10 @@ Execute the workflow now. Read entry point files to understand the architecture,
             var catalogTool = new CatalogTool(catalogStorage);
             var docTool = new DocTool(_context, branchLanguage.Id, string.Empty, gitTool);
 
+            // Incremental updates must never replace the whole catalog: exclude WriteCatalog
+            // so the agent can only modify existing structure via EditCatalog.
             var tools = BuildTools(gitTool.GetTools()
-                .Concat(catalogTool.GetTools())
+                .Concat(catalogTool.GetTools().Where(t => t.Name != "WriteCatalog"))
                 .Concat(docTool.GetTools()),
                 toolSnapshot);
 
@@ -683,7 +685,7 @@ Execute the workflow now. Read entry point files to understand the architecture,
    - Use ReadDoc(path) to read documents that need updating
    - For minor changes, use EditDoc(oldContent, newContent, path) for precise replacements
    - For major changes, use WriteDoc(content, path) to rewrite entire document
-   - If new catalog items needed, use EditCatalog or WriteCatalog
+   - If new catalog items needed, use EditCatalog to add or update individual nodes; never rewrite the whole catalog
 
 4. **Quality Requirements**
    - Ensure code examples match current implementation

--- a/src/OpenDeepWiki/prompts/incremental-updater.md
+++ b/src/OpenDeepWiki/prompts/incremental-updater.md
@@ -230,7 +230,7 @@ GitTool.Grep("\\[UserService\\]", "*.md")
 **Best Practices:**
 - ✅ Prefer EditAsync over WriteAsync for targeted changes
 - ✅ Use for updating individual items affected by code changes
-- ❌ Avoid using for bulk updates; use WriteAsync instead
+- ❌ Never use WriteAsync during incremental updates; it replaces the entire catalog
 
 ---
 
@@ -505,7 +505,7 @@ When updating catalog structure:
 | JSON format error | Check and correct format, resubmit |
 | Required field missing | Add missing fields (children defaults to []) |
 | Path format error | Convert to URL-friendly format (lowercase, hyphens) |
-| Node not found | Use WriteAsync to create new structure if needed |
+| Node not found | Re-read the catalog (ReadAsync) and retry with an existing path; never rewrite the whole catalog |
 
 ### 7.3 Document Operation Errors
 

--- a/tests/OpenDeepWiki.Tests/Services/Wiki/CatalogStorageShrinkGuardTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/Wiki/CatalogStorageShrinkGuardTests.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using OpenDeepWiki.EFCore;
+using OpenDeepWiki.Entities;
+using OpenDeepWiki.Services.Wiki;
+using Xunit;
+
+namespace OpenDeepWiki.Tests.Services.Wiki;
+
+/// <summary>
+/// Regression tests for the destructive-replacement guard in CatalogStorage.SetCatalogAsync.
+/// A populated catalog must not be silently replaced by a drastically smaller one
+/// (e.g. an incremental-update agent rewriting the whole catalog from a partial view),
+/// while initial generation (empty storage) and comparable replacements stay allowed.
+/// </summary>
+public class CatalogStorageShrinkGuardTests : IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private class TestDbContext : MasterDbContext
+    {
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+    }
+
+    private readonly TestDbContext _context;
+    private readonly string _branchLanguageId;
+
+    public CatalogStorageShrinkGuardTests()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new TestDbContext(options);
+        _context.Database.EnsureCreated();
+
+        _branchLanguageId = Guid.NewGuid().ToString();
+    }
+
+    public void Dispose()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+    }
+
+    private static string CatalogJsonWithRootItems(int count)
+    {
+        var root = new CatalogRoot();
+        for (var i = 1; i <= count; i++)
+        {
+            root.Items.Add(new CatalogItem
+            {
+                Title = $"Section {i}",
+                Path = $"{i}-section",
+                Order = i
+            });
+        }
+
+        return JsonSerializer.Serialize(root, JsonOptions);
+    }
+
+    private Task<int> LiveCatalogCountAsync()
+    {
+        return _context.DocCatalogs
+            .CountAsync(c => c.BranchLanguageId == _branchLanguageId && !c.IsDeleted);
+    }
+
+    [Fact]
+    public async Task SetCatalogAsync_EmptyStorage_AllowsInitialWrite()
+    {
+        var storage = new CatalogStorage(_context, _branchLanguageId);
+
+        await storage.SetCatalogAsync(CatalogJsonWithRootItems(3));
+
+        Assert.Equal(3, await LiveCatalogCountAsync());
+    }
+
+    [Fact]
+    public async Task SetCatalogAsync_PopulatedCatalog_RefusesDrasticShrink()
+    {
+        var storage = new CatalogStorage(_context, _branchLanguageId);
+        await storage.SetCatalogAsync(CatalogJsonWithRootItems(12));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => storage.SetCatalogAsync(CatalogJsonWithRootItems(3)));
+
+        // The original catalog must survive the rejected replacement.
+        Assert.Equal(12, await LiveCatalogCountAsync());
+    }
+
+    [Fact]
+    public async Task SetCatalogAsync_PopulatedCatalog_AllowsComparableReplacement()
+    {
+        var storage = new CatalogStorage(_context, _branchLanguageId);
+        await storage.SetCatalogAsync(CatalogJsonWithRootItems(12));
+
+        await storage.SetCatalogAsync(CatalogJsonWithRootItems(10));
+
+        Assert.Equal(10, await LiveCatalogCountAsync());
+    }
+
+    [Fact]
+    public async Task SetCatalogAsync_SmallCatalog_AllowsRewrite()
+    {
+        var storage = new CatalogStorage(_context, _branchLanguageId);
+        await storage.SetCatalogAsync(CatalogJsonWithRootItems(5));
+
+        await storage.SetCatalogAsync(CatalogJsonWithRootItems(1));
+
+        Assert.Equal(1, await LiveCatalogCountAsync());
+    }
+}


### PR DESCRIPTION
## Summary

During an incremental update the agent can call the `WriteCatalog` tool, which replaces the **entire** document catalog of a branch language with whatever the agent supplies — and the agent only sees the changed files of the latest commits. This PR removes `WriteCatalog` from the incremental-update toolset, stops the prompts from recommending whole-catalog rewrites, and adds a defense-in-depth guard in `CatalogStorage.SetCatalogAsync` so no code path can silently replace a populated catalog with a drastically smaller one.

## The problem — observed data loss in production

We run OpenDeepWiki internally with scheduled incremental updates enabled (the default). On a repository indexed with a 21-item English catalog:

1. New commits arrived; the hourly incremental update started processing them.
2. During one run the agent called `WriteCatalog` with a catalog covering only the changed area of the repository (3 items).
3. `SetCatalogAsync` soft-deleted **all 21** existing `DocCatalogs` rows and created the 3 new ones. The wiki went from a full documentation tree to a single section.
4. Days later the same thing happened to a second language of the same repository — that time during a task that **completed successfully**, so this is not tied to failed runs. Two of our four languages were wiped; the other two survived only because the agent happened to use `EditCatalog` there. The outcome is nondeterministic.

The failure is completely silent: the update task and the repository both finish in `Completed` status, no error is logged, and the wiki keeps "working" — it just loses most of its pages. We only recovered because the rows are soft-deleted: we manually flipped `IsDeleted` back in the database. The `DocFiles` content rows survive, but nothing in the product can restore the catalog.

## Root cause

Four things combine into the data loss:

1. **The incremental-update agent gets the same toolset as initial generation**, including `WriteCatalog`. There is no per-operation tool filtering:
   https://github.com/AIDotNet/OpenDeepWiki/blob/878df3dab8c0b406ce59f14e4235ace7cd9811cc/src/OpenDeepWiki/Services/Wiki/WikiGenerator.cs#L658-L661

2. **`SetCatalogAsync` is unconditionally destructive**: it soft-deletes every live `DocCatalogs` row of the branch language and recreates the structure from the supplied JSON, with no sanity check on the new structure's size:
   https://github.com/AIDotNet/OpenDeepWiki/blob/878df3dab8c0b406ce59f14e4235ace7cd9811cc/src/OpenDeepWiki/Services/Wiki/CatalogStorage.cs#L55-L81

3. **The prompts actively steer the agent toward the destructive call.** The incremental-update user message offers it as a normal option ("If new catalog items needed, use EditCatalog or WriteCatalog"):
   https://github.com/AIDotNet/OpenDeepWiki/blob/878df3dab8c0b406ce59f14e4235ace7cd9811cc/src/OpenDeepWiki/Services/Wiki/WikiGenerator.cs#L686
   and the error-handling table in `incremental-updater.md` (§7.2) documents the catastrophic fallback explicitly — when `EditCatalog` fails on a path the agent guessed wrong, the recommended recovery is to rewrite the whole catalog:
   https://github.com/AIDotNet/OpenDeepWiki/blob/878df3dab8c0b406ce59f14e4235ace7cd9811cc/src/OpenDeepWiki/prompts/incremental-updater.md#L508

4. **Nothing rolls back.** Tool calls persist immediately (`SaveChangesAsync` inside the tool call), so even when the surrounding agent run later fails and is retried, the original catalog is already gone.

## The fix — three layers

| Layer | File | Change |
|-------|------|--------|
| Tool availability | `Services/Wiki/WikiGenerator.cs` | `WriteCatalog` is excluded from the incremental-update toolset; `EditCatalog` remains for structural changes. Initial generation keeps `WriteCatalog`. |
| Prompts | `WikiGenerator.cs` user message, `prompts/incremental-updater.md` | No instruction recommends whole-catalog rewrites anymore; the "Node not found" recovery now says to re-read the catalog and retry with an existing path. |
| Storage guard | `Services/Wiki/CatalogStorage.cs` | `SetCatalogAsync` throws `InvalidOperationException` instead of replacing a populated catalog (≥ 10 items) with one less than half its size. |

Design notes:

- **Guard thresholds (≥ 10 items, < 50%)**: initial generation writes into an empty catalog (`existingCatalogs.Count == 0`), so it always passes. The translation flow replaces a catalog with a same-sized translated one, so it passes. Legitimate restructurings that keep a comparable size pass. Only the pathological case — a full catalog collapsing to a fragment — is rejected.
- **Fail loud, not silent**: when the guard trips, the agent receives the exception message ("Use EditCatalog for partial updates") as the tool result and can continue with targeted edits. Losing an agent run is recoverable; losing the catalog is not.

## What this does NOT change

- Initial catalog generation (`GenerateCatalogAsync`) keeps the full toolset including `WriteCatalog`.
- `EditCatalog` semantics are unchanged.
- No API, schema, or configuration changes.

## Tests

`tests/OpenDeepWiki.Tests/Services/Wiki/CatalogStorageShrinkGuardTests.cs` (new) exercises the real `CatalogStorage` against an in-memory context:

- empty storage allows the initial write (initial generation path),
- a populated catalog refuses a drastic shrink (12 → 3) and **keeps the original rows live**,
- a comparable replacement (12 → 10) is allowed (translation/restructuring path),
- a small catalog (5 → 1) may still be rewritten (below the guard threshold).

The existing `CatalogTool` tests are unaffected and pass. Full suite: 424/425 passing — the single failure (`RepositorySkillMarkdownBuilderTests.BuildSkillMarkdown_ShouldCreateEnglishDescriptorAndDocumentIndex`) fails identically on a clean `main` checkout, so it is pre-existing and unrelated. We have also been running this exact patch in our production instance since 2026-06-12.

## Notes for reviewers

- If you would prefer the guard thresholds to be configurable (e.g. via `WikiGeneratorOptions`), I am happy to move them there.
- `EditCatalog` has a smaller-scope variant of the same issue: when the supplied node JSON contains children, all existing children of that node are soft-deleted and replaced. A follow-up could apply the same shrink guard per subtree.