### PR TITLE
Fix source file links for non-GitHub hosts (e.g. Azure DevOps)

### DIFF
--- a/src/OpenDeepWiki/Models/RepositoryDocResponse.cs
+++ b/src/OpenDeepWiki/Models/RepositoryDocResponse.cs
@@ -25,4 +25,15 @@ public class RepositoryDocResponse
     /// 记录生成此文档时读取的源代码文件路径
     /// </summary>
     public List<string> SourceFiles { get; set; } = [];
+
+    /// <summary>
+    /// Repository Git URL, used by the client to build source file links
+    /// for the correct hosting platform (GitHub, GitLab, Azure DevOps, ...).
+    /// </summary>
+    public string? GitUrl { get; set; }
+
+    /// <summary>
+    /// Branch the document was generated from, used as the ref in file links.
+    /// </summary>
+    public string? Branch { get; set; }
 }

--- a/src/OpenDeepWiki/Services/Repositories/RepositoryDocsService.cs
+++ b/src/OpenDeepWiki/Services/Repositories/RepositoryDocsService.cs
@@ -416,6 +416,8 @@ public class RepositoryDocsService(
             Slug = normalizedSlug,
             Content = docFile.Content,
             SourceFiles = sourceFiles,
+            GitUrl = repository.GitUrl,
+            Branch = branchEntity.BranchName,
             Exists = true
         };
     }

--- a/web/app/[owner]/[repo]/[...slug]/page.tsx
+++ b/web/app/[owner]/[repo]/[...slug]/page.tsx
@@ -176,9 +176,10 @@ export default async function RepoDocPage({ params, searchParams }: RepoDocPageP
           dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }}
         />
         <MarkdownRenderer content={doc.content} language={locale} />
-        <SourceFiles 
-          files={doc.sourceFiles || []} 
-          branch={branch}
+        <SourceFiles
+          files={doc.sourceFiles || []}
+          gitUrl={doc.gitUrl ?? undefined}
+          branch={doc.branch ?? branch}
         />
       </article>
       {headings.length > 0 && (

--- a/web/components/repo/source-files.tsx
+++ b/web/components/repo/source-files.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { FileCode2, ExternalLink } from "lucide-react";
-import { useParams, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useMemo } from "react";
-import { decodeRouteSegment } from "@/lib/repo-route";
 
 interface SourceFilesProps {
   files: string[];
@@ -12,20 +11,26 @@ interface SourceFilesProps {
 }
 
 /**
- * 构建文件的 Git 平台链接
+ * Build a link to a file on the repository's Git hosting platform.
+ * Returns an empty string when the repository URL is unknown.
  */
 function buildFileUrl(gitUrl: string, branch: string, filePath: string): string {
-  // 规范化 URL
+  // Without a known repository URL we cannot build a reliable link
+  if (!gitUrl) {
+    return "";
+  }
+
+  // Normalize the URL
   let normalizedUrl = gitUrl.replace(/\.git$/, "").trim();
-  
-  // 转换 SSH 格式为 HTTPS
+
+  // Convert SSH format to HTTPS
   if (normalizedUrl.startsWith("git@")) {
     normalizedUrl = normalizedUrl.replace("git@", "https://").replace(":", "/");
   }
-  
+
   normalizedUrl = normalizedUrl.replace(/\/$/, "");
-  
-  // 根据平台构建 URL
+
+  // Build the URL according to the hosting platform
   if (normalizedUrl.includes("github.com")) {
     return `${normalizedUrl}/blob/${branch}/${filePath}`;
   } else if (normalizedUrl.includes("gitlab.com") || normalizedUrl.includes("gitlab")) {
@@ -34,23 +39,23 @@ function buildFileUrl(gitUrl: string, branch: string, filePath: string): string 
     return `${normalizedUrl}/blob/${branch}/${filePath}`;
   } else if (normalizedUrl.includes("bitbucket.org")) {
     return `${normalizedUrl}/src/${branch}/${filePath}`;
+  } else if (normalizedUrl.includes("dev.azure.com") || normalizedUrl.includes("visualstudio.com")) {
+    // Azure DevOps: https://dev.azure.com/org/project/_git/repo?version=GBbranch&path=/path
+    return `${normalizedUrl}?version=GB${branch}&path=/${filePath}`;
   }
-  
-  // 默认使用 GitHub 格式
+
+  // Default: assume a GitHub-like format
   return `${normalizedUrl}/blob/${branch}/${filePath}`;
 }
 
 export function SourceFiles({ files, gitUrl, branch }: SourceFilesProps) {
-  const params = useParams();
   const searchParams = useSearchParams();
-  
-  // 从 URL 参数获取仓库信息
-  const owner = decodeRouteSegment(params.owner as string);
-  const repo = decodeRouteSegment(params.repo as string);
+
+  // Resolve the branch to link against
   const currentBranch = searchParams.get("branch") || branch || "main";
-  
-  // 构建默认的 Git URL
-  const defaultGitUrl = gitUrl || `https://github.com/${owner}/${repo}`;
+
+  // Only build links when the real repository URL is known
+  const repoGitUrl = gitUrl ?? "";
   
   // 对文件进行分组（按目录）
   const groupedFiles = useMemo(() => {
@@ -97,8 +102,22 @@ export function SourceFiles({ files, gitUrl, branch }: SourceFilesProps) {
             <div className="flex flex-wrap gap-2">
               {dirFiles.map(file => {
                 const fileName = file.split("/").pop() || file;
-                const fileUrl = buildFileUrl(defaultGitUrl, currentBranch, file);
-                
+                const fileUrl = buildFileUrl(repoGitUrl, currentBranch, file);
+
+                // Render a plain label when we cannot build a valid link
+                if (!fileUrl) {
+                  return (
+                    <span
+                      key={file}
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1 text-sm bg-fd-secondary rounded-md text-fd-foreground"
+                      title={file}
+                    >
+                      <FileCode2 className="h-3.5 w-3.5 text-fd-muted-foreground" />
+                      <span className="max-w-[200px] truncate">{fileName}</span>
+                    </span>
+                  );
+                }
+
                 return (
                   <a
                     key={file}

--- a/web/types/repository.ts
+++ b/web/types/repository.ts
@@ -52,6 +52,8 @@ export interface RepoDocResponse {
   slug: string;
   content: string;
   sourceFiles: string[];
+  gitUrl: string | null;
+  branch: string | null;
 }
 
 export interface RepoHeading {


### PR DESCRIPTION
## Problem

On a wiki page, the **"Sources"** footer renders file links that point to a
non-existent `github.com` repository when the repository is **not** hosted on
GitHub (Azure DevOps, self-hosted GitLab, etc.).

Example (Azure DevOps repo): the footer links to
`https://github.com/{owner}/{repo}/blob/{branch}/{file}` — a 404 — while the
in-content "Related Links" / source-attribution links on the same page point
to the correct Azure DevOps URL.

## Root cause

The two kinds of links are built by two different code paths:

- **In-content links** are baked server-side into the stored Markdown by
  `WikiGenerator.BuildGitFileBaseUrl`, which already detects the hosting
  platform (GitHub / GitLab / Gitee / Bitbucket / Azure DevOps). ✅ correct.
- **The "Sources" footer** is built client-side by the `SourceFiles`
  component, which diverged:
  1. It was never passed the repository git URL, so it fabricated
     `https://github.com/${owner}/${repo}` from the route params
     (`source-files.tsx`). For non-GitHub repos this is a dead link.
  2. `buildFileUrl` had **no Azure DevOps case**, so even with a real git URL
     it fell back to the GitHub `/blob/` format, which is invalid for ADO.

The docs API (`RepositoryDocResponse`) did not expose the repository git URL,
so the component had nothing correct to use.

## Fix

- **Backend:** return `GitUrl` and `Branch` from the docs API
  (`RepositoryDocResponse`, populated in `RepositoryDocsService.GetDocAsync`
  from the repository entity and the resolved branch).
- **Frontend:** thread `gitUrl` and `branch` into `SourceFiles`; add an Azure
  DevOps format to `buildFileUrl` (`?version=GB{branch}&path=/{file}`,
  mirroring the backend); and remove the hardcoded `github.com` fallback — when
  the git URL is unknown the file is shown as a plain label instead of a broken
  link.

## Notes

- No data migration required: footer links are computed at render time, so the
  fix retroactively corrects all existing repositories. Stored content is
  unchanged.
- GitHub-hosted repositories keep the existing `/blob/` behaviour.

## Verification

- `dotnet build` — 0 errors.
- Frontend `tsc --noEmit` and `eslint` on the changed files — clean.
