### PR TITLE
RAM-36: honor branches for local git sources

### DIFF
--- a/src/OpenDeepWiki/Dockerfile
+++ b/src/OpenDeepWiki/Dockerfile
@@ -1,6 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential python3-dev \
+        build-essential git python3-dev \
         libkrb5-3 curl python3 python3-pip \
     && pip3 install --break-system-packages --no-cache-dir "graphifyy[openai,gemini,kimi,ollama]" anthropic \
     && rm -rf /var/lib/apt/lists/*

--- a/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
+++ b/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
@@ -457,6 +457,7 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
     {
         var sourceSafeDirectories = BuildGitCliSafeDirectories(sourcePath);
         var workspaceSafeDirectories = BuildGitCliSafeDirectories(workspace.WorkingDirectory, sourcePath);
+        var sourceUploadPackArgument = BuildGitCliUploadPackArgument(sourceSafeDirectories);
 
         var targetCommit = await GetGitCliBranchHeadCommitAsync(
                 sourcePath,
@@ -478,7 +479,7 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         {
             await RunGitCliAsync(
                 workspace.WorkingDirectory,
-                ["fetch", "origin"],
+                ["fetch", sourceUploadPackArgument, "origin"],
                 cancellationToken,
                 throwOnError: true,
                 safeDirectories: workspaceSafeDirectories);
@@ -498,7 +499,14 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
             Directory.CreateDirectory(Path.GetDirectoryName(workspace.WorkingDirectory)!);
             await RunGitCliAsync(
                 Directory.GetCurrentDirectory(),
-                ["clone", "--no-checkout", sourcePath, workspace.WorkingDirectory],
+                [
+                    "clone",
+                    "--no-local",
+                    sourceUploadPackArgument,
+                    "--no-checkout",
+                    sourcePath,
+                    workspace.WorkingDirectory
+                ],
                 cancellationToken,
                 throwOnError: true,
                 safeDirectories: BuildGitCliSafeDirectories(sourcePath, workspace.WorkingDirectory));
@@ -507,7 +515,7 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         workspaceSafeDirectories = BuildGitCliSafeDirectories(workspace.WorkingDirectory, sourcePath);
         await RunGitCliAsync(
             workspace.WorkingDirectory,
-            ["fetch", "origin"],
+            ["fetch", sourceUploadPackArgument, "origin"],
             cancellationToken,
             throwOnError: true,
             safeDirectories: workspaceSafeDirectories);
@@ -896,9 +904,10 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         IReadOnlyList<string> safeDirectories)
     {
         _logger.LogInformation(
-            "Running git command. WorkingDirectory: {WorkingDirectory}, Arguments: {Arguments}, SafeDirectories: {SafeDirectories}",
+            "Running git command. WorkingDirectory: {WorkingDirectory}, Arguments: {Arguments}, FullArguments: {FullArguments}, SafeDirectories: {SafeDirectories}",
             workingDirectory,
             string.Join(' ', arguments),
+            string.Join(' ', BuildGitCliProcessArguments(arguments, safeDirectories).Select(QuoteGitCliArgumentForLog)),
             string.Join(", ", safeDirectories));
     }
 
@@ -917,18 +926,62 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
             CreateNoWindow = true
         };
 
-        foreach (var safeDirectory in safeDirectories.Where(path => !string.IsNullOrWhiteSpace(path)))
-        {
-            startInfo.ArgumentList.Add("-c");
-            startInfo.ArgumentList.Add($"safe.directory={safeDirectory}");
-        }
-
-        foreach (var argument in arguments)
+        foreach (var argument in BuildGitCliProcessArguments(arguments, safeDirectories))
         {
             startInfo.ArgumentList.Add(argument);
         }
 
         return Process.Start(startInfo);
+    }
+
+    private static IEnumerable<string> BuildGitCliProcessArguments(
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<string> safeDirectories)
+    {
+        foreach (var safeDirectory in safeDirectories.Where(path => !string.IsNullOrWhiteSpace(path)))
+        {
+            yield return "-c";
+            yield return $"safe.directory={safeDirectory}";
+        }
+
+        foreach (var argument in arguments)
+        {
+            yield return argument;
+        }
+    }
+
+    private static string BuildGitCliUploadPackArgument(IReadOnlyList<string> safeDirectories)
+    {
+        var uploadPackArguments = new List<string> { "git" };
+        foreach (var safeDirectory in safeDirectories.Where(path => !string.IsNullOrWhiteSpace(path)))
+        {
+            uploadPackArguments.Add("-c");
+            uploadPackArguments.Add($"safe.directory={safeDirectory}");
+        }
+
+        uploadPackArguments.Add("upload-pack");
+        return $"--upload-pack={string.Join(' ', uploadPackArguments.Select(QuoteGitCliArgumentForShell))}";
+    }
+
+    private static string QuoteGitCliArgumentForLog(string argument)
+    {
+        return argument.Any(char.IsWhiteSpace)
+            ? $"\"{argument.Replace("\"", "\\\"", StringComparison.Ordinal)}\""
+            : argument;
+    }
+
+    private static string QuoteGitCliArgumentForShell(string argument)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return argument.Any(char.IsWhiteSpace)
+                ? $"\"{argument.Replace("\"", "\\\"", StringComparison.Ordinal)}\""
+                : argument;
+        }
+
+        return argument.Contains('\'', StringComparison.Ordinal) || argument.Any(char.IsWhiteSpace)
+            ? $"'{argument.Replace("'", "'\"'\"'", StringComparison.Ordinal)}'"
+            : argument;
     }
 
     private static IReadOnlyList<string> BuildGitCliSafeDirectories(params string[] paths)

--- a/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
+++ b/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
@@ -80,6 +80,19 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         }
 
         var sourceInfo = RepositorySource.Parse(repository.GitUrl);
+        if (sourceInfo.SourceType == RepositorySourceType.LocalDirectory &&
+            IsLocalGitRepository(sourceInfo.Location))
+        {
+            return await Task.Run(() =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                using var localRepository = new GitRepository(sourceInfo.Location);
+                var branch = localRepository.Branches[branchName];
+                return branch?.Tip?.Sha;
+            }, cancellationToken);
+        }
+
         if (sourceInfo.SourceType != RepositorySourceType.Git)
         {
             _logger.LogDebug(
@@ -175,6 +188,12 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         {
             await PrepareArchiveWorkspaceAsync(workspace, cancellationToken);
             workspace.CommitId = ComputeDirectorySnapshotId(workspace.WorkingDirectory);
+        }
+        else if (IsLocalGitRepository(workspace.SourceLocation))
+        {
+            await PrepareLocalGitWorkspaceAsync(workspace, cancellationToken);
+            workspace.CommitId = GetHeadCommitId(workspace.WorkingDirectory);
+            workspace.SupportsIncrementalUpdates = true;
         }
         else
         {
@@ -353,6 +372,46 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         CopyDirectory(workspace.SourceLocation, workspace.WorkingDirectory);
     }
 
+    private async Task PrepareLocalGitWorkspaceAsync(
+        RepositoryWorkspace workspace,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(workspace.SourceLocation) || !Directory.Exists(workspace.SourceLocation))
+        {
+            throw new DirectoryNotFoundException($"Local git source not found: {workspace.SourceLocation}");
+        }
+
+        _logger.LogInformation(
+            "Preparing local git workspace from target branch. SourcePath: {SourcePath}, Branch: {Branch}, TargetPath: {Path}",
+            workspace.SourceLocation, workspace.BranchName, workspace.WorkingDirectory);
+
+        var originalGitUrl = workspace.GitUrl;
+        workspace.GitUrl = workspace.SourceLocation;
+
+        try
+        {
+            var repoExists = Directory.Exists(workspace.WorkingDirectory) &&
+                             Directory.Exists(Path.Combine(workspace.WorkingDirectory, ".git"));
+
+            if (repoExists)
+            {
+                await PullRepositoryAsync(workspace, credentials: null, cancellationToken);
+            }
+            else
+            {
+                await CloneRepositoryAsync(workspace, credentials: null, cancellationToken);
+            }
+
+            workspace.LocalDirectoryImportModeUsed = LocalDirectoryImportMode.Copy;
+        }
+        finally
+        {
+            workspace.GitUrl = originalGitUrl;
+        }
+    }
+
     private void CopyDirectory(string sourceDirectory, string destinationDirectory)
     {
         var sourceInfo = new DirectoryInfo(sourceDirectory);
@@ -425,6 +484,28 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
     {
         return !string.IsNullOrEmpty(fileSystemInfo.LinkTarget) ||
                fileSystemInfo.Attributes.HasFlag(FileAttributes.ReparsePoint);
+    }
+
+    private static bool IsLocalGitRepository(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+        {
+            return false;
+        }
+
+        if (Directory.Exists(Path.Combine(path, ".git")) || File.Exists(Path.Combine(path, ".git")))
+        {
+            return true;
+        }
+
+        try
+        {
+            return GitRepository.IsValid(path);
+        }
+        catch (LibGit2SharpException)
+        {
+            return false;
+        }
     }
 
     private static string ComputeDirectorySnapshotId(string directoryPath)

--- a/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
+++ b/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
@@ -80,11 +80,13 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         }
 
         var sourceInfo = RepositorySource.Parse(repository.GitUrl);
+        var exactFailureReason = "not evaluated";
         if (sourceInfo.SourceType == RepositorySourceType.LocalDirectory &&
-            TryOpenExactGitWorkdir(sourceInfo.Location, out var localRepository))
+            TryResolveLocalGitSource(sourceInfo.Location, out var localGitSource, out exactFailureReason))
         {
-            using (localRepository)
+            if (localGitSource.AccessMode == LocalGitAccessMode.LibGit2)
             {
+                using var localRepository = new GitRepository(localGitSource.RepositoryPath);
                 return await Task.Run(() =>
                 {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -92,6 +94,15 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
                     return ResolveLocalSourceBranchTip(localRepository, branchName)?.Sha;
                 }, cancellationToken);
             }
+
+            return await GetGitCliBranchHeadCommitAsync(localGitSource.RepositoryPath, branchName, cancellationToken);
+        }
+
+        if (sourceInfo.SourceType == RepositorySourceType.LocalDirectory)
+        {
+            _logger.LogInformation(
+                "Local source remote HEAD lookup skipped because decoded source is not an exact Git source. Repository: {Org}/{Repo}, Branch: {Branch}, SourcePath: {SourcePath}, Reason: {Reason}",
+                repository.OrgName, repository.RepoName, branchName, sourceInfo.Location, exactFailureReason);
         }
 
         if (sourceInfo.SourceType != RepositorySourceType.Git)
@@ -148,8 +159,9 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         };
 
         _logger.LogInformation(
-            "Preparing workspace. Repository: {Org}/{Repo}, Branch: {Branch}, WorkingDirectory: {Path}, PreviousCommit: {PreviousCommit}",
-            workspace.Organization, workspace.RepositoryName, branchName, 
+            "Preparing workspace. Repository: {Org}/{Repo}, Branch: {Branch}, SourceType: {SourceType}, SourceLocation: {SourceLocation}, WorkingDirectory: {Path}, PreviousCommit: {PreviousCommit}",
+            workspace.Organization, workspace.RepositoryName, branchName,
+            workspace.SourceType, workspace.SourceLocation,
             workspace.WorkingDirectory, previousCommitId ?? "none");
 
         // Ensure the parent directory exists
@@ -190,14 +202,21 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
             await PrepareArchiveWorkspaceAsync(workspace, cancellationToken);
             workspace.CommitId = ComputeDirectorySnapshotId(workspace.WorkingDirectory);
         }
-        else if (IsLocalGitRepository(workspace.SourceLocation))
+        else if (TryResolveLocalGitSource(workspace.SourceLocation, out var localGitSource, out var localGitFailureReason))
         {
-            await PrepareLocalGitWorkspaceAsync(workspace, cancellationToken);
+            await PrepareLocalGitWorkspaceAsync(workspace, localGitSource, cancellationToken);
             workspace.CommitId = GetHeadCommitId(workspace.WorkingDirectory);
             workspace.SupportsIncrementalUpdates = true;
         }
         else
         {
+            if (workspace.SourceType == RepositorySourceType.LocalDirectory)
+            {
+                _logger.LogWarning(
+                    "Decoded local source is not an exact Git source; falling back to local directory snapshot. SourcePath: {SourcePath}, Branch: {Branch}, WorkingDirectory: {Path}, Reason: {Reason}",
+                    workspace.SourceLocation, workspace.BranchName, workspace.WorkingDirectory, localGitFailureReason);
+            }
+
             await PrepareLocalDirectoryWorkspaceAsync(workspace, cancellationToken);
             workspace.CommitId = ComputeDirectorySnapshotId(workspace.WorkingDirectory);
         }
@@ -375,51 +394,51 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
 
     private async Task PrepareLocalGitWorkspaceAsync(
         RepositoryWorkspace workspace,
+        LocalGitSource localGitSource,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (string.IsNullOrWhiteSpace(workspace.SourceLocation) || !Directory.Exists(workspace.SourceLocation))
+        if (string.IsNullOrWhiteSpace(localGitSource.RepositoryPath) || !Directory.Exists(localGitSource.RepositoryPath))
         {
-            throw new DirectoryNotFoundException($"Local git source not found: {workspace.SourceLocation}");
+            throw new DirectoryNotFoundException($"Local git source not found: {localGitSource.RepositoryPath}");
         }
 
         _logger.LogInformation(
-            "Preparing local git workspace from target branch. SourcePath: {SourcePath}, Branch: {Branch}, TargetPath: {Path}",
-            workspace.SourceLocation, workspace.BranchName, workspace.WorkingDirectory);
+            "Preparing local git workspace from target branch. SourcePath: {SourcePath}, Branch: {Branch}, TargetPath: {Path}, AccessMode: {AccessMode}",
+            localGitSource.RepositoryPath, workspace.BranchName, workspace.WorkingDirectory, localGitSource.AccessMode);
 
-        if (!TryOpenExactGitWorkdir(workspace.SourceLocation, out var sourceRepository))
+        if (localGitSource.AccessMode == LocalGitAccessMode.GitCli)
         {
-            throw new InvalidOperationException($"Local git source is not an exact Git workdir: {workspace.SourceLocation}");
+            await PrepareLocalGitWorkspaceWithCliAsync(workspace, localGitSource.RepositoryPath, cancellationToken);
+            return;
         }
 
-        using (sourceRepository)
-        {
-            var targetTip = ResolveLocalSourceBranchTip(sourceRepository, workspace.BranchName)
-                ?? throw new InvalidOperationException(
-                    $"Branch '{workspace.BranchName}' not found in local git source: {workspace.SourceLocation}");
+        using var sourceRepository = new GitRepository(localGitSource.RepositoryPath);
+        var targetTip = ResolveLocalSourceBranchTip(sourceRepository, workspace.BranchName)
+            ?? throw new InvalidOperationException(
+                $"Branch '{workspace.BranchName}' not found in local git source: {localGitSource.RepositoryPath}");
 
-            _logger.LogInformation(
-                "Resolved local git source branch. SourcePath: {SourcePath}, Branch: {Branch}, Commit: {CommitId}",
-                workspace.SourceLocation, workspace.BranchName, targetTip.Sha);
-        }
+        _logger.LogInformation(
+            "Resolved local git source branch. SourcePath: {SourcePath}, Branch: {Branch}, Commit: {CommitId}",
+            localGitSource.RepositoryPath, workspace.BranchName, targetTip.Sha);
 
         var originalGitUrl = workspace.GitUrl;
-        workspace.GitUrl = workspace.SourceLocation;
+        workspace.GitUrl = localGitSource.RepositoryPath;
 
         try
         {
-            if (IsValidWorkspaceForSource(workspace.WorkingDirectory, workspace.SourceLocation))
+            if (IsValidWorkspaceForSource(workspace.WorkingDirectory, localGitSource.RepositoryPath, out var workspaceReason))
             {
                 await PullRepositoryAsync(workspace, credentials: null, cancellationToken);
             }
             else
             {
                 _logger.LogWarning(
-                    "Existing local git workspace is missing, invalid, or points at a different source; recloning. SourcePath: {SourcePath}, Branch: {Branch}, TargetPath: {Path}",
-                    workspace.SourceLocation, workspace.BranchName, workspace.WorkingDirectory);
+                    "Existing local git workspace is missing, invalid, or points at a different source; recloning. SourcePath: {SourcePath}, Branch: {Branch}, TargetPath: {Path}, Reason: {Reason}",
+                    localGitSource.RepositoryPath, workspace.BranchName, workspace.WorkingDirectory, workspaceReason);
 
-                DeleteWorkspaceDirectoryWithinRepositoryRoot(workspace.WorkingDirectory, workspace.SourceLocation);
+                DeleteWorkspaceDirectoryWithinRepositoryRoot(workspace.WorkingDirectory, localGitSource.RepositoryPath);
                 await CloneRepositoryAsync(workspace, credentials: null, cancellationToken);
             }
 
@@ -429,6 +448,46 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         {
             workspace.GitUrl = originalGitUrl;
         }
+    }
+
+    private async Task PrepareLocalGitWorkspaceWithCliAsync(
+        RepositoryWorkspace workspace,
+        string sourcePath,
+        CancellationToken cancellationToken)
+    {
+        var targetCommit = await GetGitCliBranchHeadCommitAsync(sourcePath, workspace.BranchName, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Branch '{workspace.BranchName}' not found in local git source: {sourcePath}");
+
+        _logger.LogInformation(
+            "Resolved local git source branch via git CLI. SourcePath: {SourcePath}, Branch: {Branch}, Commit: {CommitId}",
+            sourcePath, workspace.BranchName, targetCommit);
+
+        if (await IsValidGitCliWorkspaceForSourceAsync(workspace.WorkingDirectory, sourcePath, cancellationToken))
+        {
+            await RunGitCliAsync(workspace.WorkingDirectory, ["fetch", "origin"], cancellationToken, throwOnError: true);
+        }
+        else
+        {
+            var reason = await GetGitCliWorkspaceInvalidReasonAsync(workspace.WorkingDirectory, sourcePath, cancellationToken);
+            _logger.LogWarning(
+                "Existing local git workspace is missing, invalid, or points at a different source; recloning. SourcePath: {SourcePath}, Branch: {Branch}, TargetPath: {Path}, Reason: {Reason}",
+                sourcePath, workspace.BranchName, workspace.WorkingDirectory, reason);
+
+            DeleteWorkspaceDirectoryWithinRepositoryRoot(workspace.WorkingDirectory, sourcePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(workspace.WorkingDirectory)!);
+            await RunGitCliAsync(
+                Directory.GetCurrentDirectory(),
+                ["clone", "--no-checkout", sourcePath, workspace.WorkingDirectory],
+                cancellationToken,
+                throwOnError: true);
+        }
+
+        await RunGitCliAsync(workspace.WorkingDirectory, ["fetch", "origin"], cancellationToken, throwOnError: true);
+        await RunGitCliAsync(workspace.WorkingDirectory, ["checkout", "-B", workspace.BranchName, targetCommit], cancellationToken, throwOnError: true);
+        await RunGitCliAsync(workspace.WorkingDirectory, ["reset", "--hard", targetCommit], cancellationToken, throwOnError: true);
+
+        workspace.LocalDirectoryImportModeUsed = LocalDirectoryImportMode.Copy;
     }
 
     private void CopyDirectory(string sourceDirectory, string destinationDirectory)
@@ -505,15 +564,35 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
                fileSystemInfo.Attributes.HasFlag(FileAttributes.ReparsePoint);
     }
 
-    private static bool IsLocalGitRepository(string path)
+    private bool TryResolveLocalGitSource(
+        string path,
+        out LocalGitSource localGitSource,
+        out string failureReason)
     {
-        if (!TryOpenExactGitWorkdir(path, out var repository))
+        localGitSource = default;
+
+        if (TryOpenExactGitWorkdir(path, out var repository, out failureReason))
         {
-            return false;
+            repository.Dispose();
+            localGitSource = new LocalGitSource(path, LocalGitAccessMode.LibGit2);
+            _logger.LogInformation(
+                "Decoded local source path is an exact Git workdir. SourcePath: {SourcePath}, AccessMode: {AccessMode}",
+                path, localGitSource.AccessMode);
+            return true;
         }
 
-        repository.Dispose();
-        return true;
+        if (TryResolveGitCliExactWorkdir(path, out var cliTopLevel, out var cliFailureReason))
+        {
+            localGitSource = new LocalGitSource(path, LocalGitAccessMode.GitCli);
+            failureReason = $"LibGit2 exact workdir failed: {failureReason}; git CLI exact workdir succeeded: {cliTopLevel}";
+            _logger.LogWarning(
+                "Decoded local source path is an exact Git workdir via git CLI fallback. SourcePath: {SourcePath}, TopLevel: {TopLevel}, LibGit2Reason: {LibGit2Reason}",
+                path, cliTopLevel, failureReason);
+            return true;
+        }
+
+        failureReason = $"LibGit2 exact workdir failed: {failureReason}; git CLI exact workdir failed: {cliFailureReason}";
+        return false;
     }
 
     private static Commit? ResolveLocalSourceBranchTip(GitRepository repository, string branchName)
@@ -522,9 +601,9 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
                repository.Branches[$"origin/{branchName}"]?.Tip;
     }
 
-    private static bool IsValidWorkspaceForSource(string workspacePath, string sourcePath)
+    private static bool IsValidWorkspaceForSource(string workspacePath, string sourcePath, out string reason)
     {
-        if (!TryOpenExactGitWorkdir(workspacePath, out var repository))
+        if (!TryOpenExactGitWorkdir(workspacePath, out var repository, out reason))
         {
             return false;
         }
@@ -532,16 +611,31 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         using (repository)
         {
             var remote = repository.Network.Remotes["origin"];
-            return remote != null && LocalPathEquals(remote.Url, sourcePath);
+            if (remote == null)
+            {
+                reason = "workspace has no origin remote";
+                return false;
+            }
+
+            if (!LocalPathEquals(remote.Url, sourcePath))
+            {
+                reason = $"workspace origin '{remote.Url}' does not match source '{sourcePath}'";
+                return false;
+            }
+
+            reason = "workspace is an exact Git workdir and origin matches source";
+            return true;
         }
     }
 
-    private static bool TryOpenExactGitWorkdir(string path, out GitRepository repository)
+    private static bool TryOpenExactGitWorkdir(string path, out GitRepository repository, out string reason)
     {
         repository = null!;
+        reason = "unknown";
 
         if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
         {
+            reason = $"path does not exist or is not a directory: {path}";
             return false;
         }
 
@@ -551,21 +645,213 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
             var workingDirectory = candidate.Info.WorkingDirectory;
             if (!LocalPathEquals(workingDirectory, path))
             {
+                reason = $"opened Git workdir root '{workingDirectory}' does not equal requested path '{path}'";
                 candidate.Dispose();
                 return false;
             }
 
             repository = candidate;
+            reason = "exact Git workdir";
             return true;
         }
-        catch (RepositoryNotFoundException)
+        catch (RepositoryNotFoundException ex)
         {
+            reason = ex.Message;
             return false;
         }
-        catch (LibGit2SharpException)
+        catch (LibGit2SharpException ex)
         {
+            reason = ex.Message;
             return false;
         }
+    }
+
+    private bool TryResolveGitCliExactWorkdir(string path, out string topLevel, out string reason)
+    {
+        topLevel = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+        {
+            reason = $"path does not exist or is not a directory: {path}";
+            return false;
+        }
+
+        var result = RunGitCli(path, ["rev-parse", "--show-toplevel"]);
+        if (result.ExitCode != 0)
+        {
+            reason = $"git rev-parse --show-toplevel failed with exit {result.ExitCode}: {result.Error}";
+            return false;
+        }
+
+        topLevel = result.Output.Trim();
+        if (!LocalPathEquals(topLevel, path))
+        {
+            reason = $"git CLI workdir root '{topLevel}' does not equal requested path '{path}'";
+            return false;
+        }
+
+        reason = "exact Git workdir via git CLI";
+        return true;
+    }
+
+    private async Task<string?> GetGitCliBranchHeadCommitAsync(
+        string sourcePath,
+        string branchName,
+        CancellationToken cancellationToken)
+    {
+        var localResult = await RunGitCliAsync(
+            sourcePath,
+            ["rev-parse", "--verify", $"{branchName}^{{commit}}"],
+            cancellationToken,
+            throwOnError: false);
+        if (localResult.ExitCode == 0)
+        {
+            return localResult.Output.Trim();
+        }
+
+        var remoteResult = await RunGitCliAsync(
+            sourcePath,
+            ["rev-parse", "--verify", $"origin/{branchName}^{{commit}}"],
+            cancellationToken,
+            throwOnError: false);
+        if (remoteResult.ExitCode == 0)
+        {
+            return remoteResult.Output.Trim();
+        }
+
+        _logger.LogWarning(
+            "Unable to resolve local git source branch via git CLI. SourcePath: {SourcePath}, Branch: {Branch}, LocalError: {LocalError}, RemoteError: {RemoteError}",
+            sourcePath, branchName, localResult.Error, remoteResult.Error);
+        return null;
+    }
+
+    private async Task<bool> IsValidGitCliWorkspaceForSourceAsync(
+        string workspacePath,
+        string sourcePath,
+        CancellationToken cancellationToken)
+    {
+        return string.Equals(
+            await GetGitCliWorkspaceInvalidReasonAsync(workspacePath, sourcePath, cancellationToken),
+            "workspace is an exact Git workdir and origin matches source",
+            StringComparison.Ordinal);
+    }
+
+    private async Task<string> GetGitCliWorkspaceInvalidReasonAsync(
+        string workspacePath,
+        string sourcePath,
+        CancellationToken cancellationToken)
+    {
+        if (!Directory.Exists(workspacePath))
+        {
+            return $"workspace path does not exist: {workspacePath}";
+        }
+
+        var topLevelResult = await RunGitCliAsync(
+            workspacePath,
+            ["rev-parse", "--show-toplevel"],
+            cancellationToken,
+            throwOnError: false);
+        if (topLevelResult.ExitCode != 0)
+        {
+            return $"git rev-parse --show-toplevel failed with exit {topLevelResult.ExitCode}: {topLevelResult.Error}";
+        }
+
+        var topLevel = topLevelResult.Output.Trim();
+        if (!LocalPathEquals(topLevel, workspacePath))
+        {
+            return $"workspace Git root '{topLevel}' does not equal target path '{workspacePath}'";
+        }
+
+        var originResult = await RunGitCliAsync(
+            workspacePath,
+            ["remote", "get-url", "origin"],
+            cancellationToken,
+            throwOnError: false);
+        if (originResult.ExitCode != 0)
+        {
+            return $"git remote get-url origin failed with exit {originResult.ExitCode}: {originResult.Error}";
+        }
+
+        var originUrl = originResult.Output.Trim();
+        if (!LocalPathEquals(originUrl, sourcePath))
+        {
+            return $"workspace origin '{originUrl}' does not match source '{sourcePath}'";
+        }
+
+        return "workspace is an exact Git workdir and origin matches source";
+    }
+
+    private GitCliResult RunGitCli(string workingDirectory, IReadOnlyList<string> arguments)
+    {
+        try
+        {
+            using var process = StartGitCli(workingDirectory, arguments);
+            if (process == null)
+            {
+                return new GitCliResult(-1, string.Empty, "Failed to start git process");
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            return new GitCliResult(process.ExitCode, output.Trim(), error.Trim());
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or FileNotFoundException)
+        {
+            return new GitCliResult(-1, string.Empty, ex.Message);
+        }
+    }
+
+    private async Task<GitCliResult> RunGitCliAsync(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken,
+        bool throwOnError)
+    {
+        using var process = StartGitCli(workingDirectory, arguments);
+        if (process == null)
+        {
+            throw new InvalidOperationException("Failed to start git process");
+        }
+
+        var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+        var result = new GitCliResult(
+            process.ExitCode,
+            (await outputTask).Trim(),
+            (await errorTask).Trim());
+
+        if (throwOnError && result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"git {string.Join(' ', arguments)} failed in {workingDirectory} with exit {result.ExitCode}: {result.Error}");
+        }
+
+        return result;
+    }
+
+    private static Process? StartGitCli(string workingDirectory, IReadOnlyList<string> arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add("safe.directory=*");
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return Process.Start(startInfo);
     }
 
     private void DeleteWorkspaceDirectoryWithinRepositoryRoot(string workspacePath, string sourcePath)
@@ -629,6 +915,16 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         return OperatingSystem.IsWindows()
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
+    }
+
+    private readonly record struct LocalGitSource(string RepositoryPath, LocalGitAccessMode AccessMode);
+
+    private readonly record struct GitCliResult(int ExitCode, string Output, string Error);
+
+    private enum LocalGitAccessMode
+    {
+        LibGit2,
+        GitCli
     }
 
     private static string ComputeDirectorySnapshotId(string directoryPath)

--- a/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
+++ b/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
@@ -81,16 +81,17 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
 
         var sourceInfo = RepositorySource.Parse(repository.GitUrl);
         if (sourceInfo.SourceType == RepositorySourceType.LocalDirectory &&
-            IsLocalGitRepository(sourceInfo.Location))
+            TryOpenExactGitWorkdir(sourceInfo.Location, out var localRepository))
         {
-            return await Task.Run(() =>
+            using (localRepository)
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                return await Task.Run(() =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                using var localRepository = new GitRepository(sourceInfo.Location);
-                var branch = localRepository.Branches[branchName];
-                return branch?.Tip?.Sha;
-            }, cancellationToken);
+                    return ResolveLocalSourceBranchTip(localRepository, branchName)?.Sha;
+                }, cancellationToken);
+            }
         }
 
         if (sourceInfo.SourceType != RepositorySourceType.Git)
@@ -387,20 +388,38 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
             "Preparing local git workspace from target branch. SourcePath: {SourcePath}, Branch: {Branch}, TargetPath: {Path}",
             workspace.SourceLocation, workspace.BranchName, workspace.WorkingDirectory);
 
+        if (!TryOpenExactGitWorkdir(workspace.SourceLocation, out var sourceRepository))
+        {
+            throw new InvalidOperationException($"Local git source is not an exact Git workdir: {workspace.SourceLocation}");
+        }
+
+        using (sourceRepository)
+        {
+            var targetTip = ResolveLocalSourceBranchTip(sourceRepository, workspace.BranchName)
+                ?? throw new InvalidOperationException(
+                    $"Branch '{workspace.BranchName}' not found in local git source: {workspace.SourceLocation}");
+
+            _logger.LogInformation(
+                "Resolved local git source branch. SourcePath: {SourcePath}, Branch: {Branch}, Commit: {CommitId}",
+                workspace.SourceLocation, workspace.BranchName, targetTip.Sha);
+        }
+
         var originalGitUrl = workspace.GitUrl;
         workspace.GitUrl = workspace.SourceLocation;
 
         try
         {
-            var repoExists = Directory.Exists(workspace.WorkingDirectory) &&
-                             Directory.Exists(Path.Combine(workspace.WorkingDirectory, ".git"));
-
-            if (repoExists)
+            if (IsValidWorkspaceForSource(workspace.WorkingDirectory, workspace.SourceLocation))
             {
                 await PullRepositoryAsync(workspace, credentials: null, cancellationToken);
             }
             else
             {
+                _logger.LogWarning(
+                    "Existing local git workspace is missing, invalid, or points at a different source; recloning. SourcePath: {SourcePath}, Branch: {Branch}, TargetPath: {Path}",
+                    workspace.SourceLocation, workspace.BranchName, workspace.WorkingDirectory);
+
+                DeleteWorkspaceDirectoryWithinRepositoryRoot(workspace.WorkingDirectory, workspace.SourceLocation);
                 await CloneRepositoryAsync(workspace, credentials: null, cancellationToken);
             }
 
@@ -488,24 +507,128 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
 
     private static bool IsLocalGitRepository(string path)
     {
+        if (!TryOpenExactGitWorkdir(path, out var repository))
+        {
+            return false;
+        }
+
+        repository.Dispose();
+        return true;
+    }
+
+    private static Commit? ResolveLocalSourceBranchTip(GitRepository repository, string branchName)
+    {
+        return repository.Branches[branchName]?.Tip ??
+               repository.Branches[$"origin/{branchName}"]?.Tip;
+    }
+
+    private static bool IsValidWorkspaceForSource(string workspacePath, string sourcePath)
+    {
+        if (!TryOpenExactGitWorkdir(workspacePath, out var repository))
+        {
+            return false;
+        }
+
+        using (repository)
+        {
+            var remote = repository.Network.Remotes["origin"];
+            return remote != null && LocalPathEquals(remote.Url, sourcePath);
+        }
+    }
+
+    private static bool TryOpenExactGitWorkdir(string path, out GitRepository repository)
+    {
+        repository = null!;
+
         if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
         {
             return false;
         }
 
-        if (Directory.Exists(Path.Combine(path, ".git")) || File.Exists(Path.Combine(path, ".git")))
-        {
-            return true;
-        }
-
         try
         {
-            return GitRepository.IsValid(path);
+            var candidate = new GitRepository(path);
+            var workingDirectory = candidate.Info.WorkingDirectory;
+            if (!LocalPathEquals(workingDirectory, path))
+            {
+                candidate.Dispose();
+                return false;
+            }
+
+            repository = candidate;
+            return true;
+        }
+        catch (RepositoryNotFoundException)
+        {
+            return false;
         }
         catch (LibGit2SharpException)
         {
             return false;
         }
+    }
+
+    private void DeleteWorkspaceDirectoryWithinRepositoryRoot(string workspacePath, string sourcePath)
+    {
+        if (!Directory.Exists(workspacePath))
+        {
+            return;
+        }
+
+        var normalizedWorkspace = NormalizeLocalPath(workspacePath);
+        var normalizedSource = NormalizeLocalPath(sourcePath);
+        if (PathsEqual(normalizedWorkspace, normalizedSource))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to delete local git source while preparing workspace: {workspacePath}");
+        }
+
+        var normalizedRoot = NormalizeLocalPath(_options.RepositoriesDirectory);
+        if (PathsEqual(normalizedWorkspace, normalizedRoot) ||
+            !IsPathUnder(normalizedWorkspace, normalizedRoot))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to delete workspace outside repository root. Workspace: {workspacePath}, Root: {_options.RepositoriesDirectory}");
+        }
+
+        DeleteDirectoryRecursive(workspacePath);
+    }
+
+    private static bool LocalPathEquals(string pathA, string pathB)
+    {
+        return PathsEqual(NormalizeLocalPath(pathA), NormalizeLocalPath(pathB));
+    }
+
+    private static bool PathsEqual(string normalizedPathA, string normalizedPathB)
+    {
+        return string.Equals(normalizedPathA, normalizedPathB, GetPathComparison());
+    }
+
+    private static bool IsPathUnder(string normalizedPath, string normalizedParent)
+    {
+        var parentWithSeparator = normalizedParent.EndsWith(Path.DirectorySeparatorChar)
+            ? normalizedParent
+            : normalizedParent + Path.DirectorySeparatorChar;
+
+        return normalizedPath.StartsWith(parentWithSeparator, GetPathComparison());
+    }
+
+    private static string NormalizeLocalPath(string path)
+    {
+        if (Uri.TryCreate(path, UriKind.Absolute, out var uri) && uri.IsFile)
+        {
+            path = uri.LocalPath;
+        }
+
+        return Path.GetFullPath(path)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    private static StringComparison GetPathComparison()
+    {
+        return OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
     }
 
     private static string ComputeDirectorySnapshotId(string directoryPath)

--- a/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
+++ b/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
@@ -455,7 +455,14 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         string sourcePath,
         CancellationToken cancellationToken)
     {
-        var targetCommit = await GetGitCliBranchHeadCommitAsync(sourcePath, workspace.BranchName, cancellationToken)
+        var sourceSafeDirectories = BuildGitCliSafeDirectories(sourcePath);
+        var workspaceSafeDirectories = BuildGitCliSafeDirectories(workspace.WorkingDirectory, sourcePath);
+
+        var targetCommit = await GetGitCliBranchHeadCommitAsync(
+                sourcePath,
+                workspace.BranchName,
+                cancellationToken,
+                sourceSafeDirectories)
             ?? throw new InvalidOperationException(
                 $"Branch '{workspace.BranchName}' not found in local git source: {sourcePath}");
 
@@ -463,13 +470,26 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
             "Resolved local git source branch via git CLI. SourcePath: {SourcePath}, Branch: {Branch}, Commit: {CommitId}",
             sourcePath, workspace.BranchName, targetCommit);
 
-        if (await IsValidGitCliWorkspaceForSourceAsync(workspace.WorkingDirectory, sourcePath, cancellationToken))
+        if (await IsValidGitCliWorkspaceForSourceAsync(
+                workspace.WorkingDirectory,
+                sourcePath,
+                workspaceSafeDirectories,
+                cancellationToken))
         {
-            await RunGitCliAsync(workspace.WorkingDirectory, ["fetch", "origin"], cancellationToken, throwOnError: true);
+            await RunGitCliAsync(
+                workspace.WorkingDirectory,
+                ["fetch", "origin"],
+                cancellationToken,
+                throwOnError: true,
+                safeDirectories: workspaceSafeDirectories);
         }
         else
         {
-            var reason = await GetGitCliWorkspaceInvalidReasonAsync(workspace.WorkingDirectory, sourcePath, cancellationToken);
+            var reason = await GetGitCliWorkspaceInvalidReasonAsync(
+                workspace.WorkingDirectory,
+                sourcePath,
+                workspaceSafeDirectories,
+                cancellationToken);
             _logger.LogWarning(
                 "Existing local git workspace is missing, invalid, or points at a different source; recloning. SourcePath: {SourcePath}, Branch: {Branch}, TargetPath: {Path}, Reason: {Reason}",
                 sourcePath, workspace.BranchName, workspace.WorkingDirectory, reason);
@@ -480,12 +500,29 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
                 Directory.GetCurrentDirectory(),
                 ["clone", "--no-checkout", sourcePath, workspace.WorkingDirectory],
                 cancellationToken,
-                throwOnError: true);
+                throwOnError: true,
+                safeDirectories: BuildGitCliSafeDirectories(sourcePath, workspace.WorkingDirectory));
         }
 
-        await RunGitCliAsync(workspace.WorkingDirectory, ["fetch", "origin"], cancellationToken, throwOnError: true);
-        await RunGitCliAsync(workspace.WorkingDirectory, ["checkout", "-B", workspace.BranchName, targetCommit], cancellationToken, throwOnError: true);
-        await RunGitCliAsync(workspace.WorkingDirectory, ["reset", "--hard", targetCommit], cancellationToken, throwOnError: true);
+        workspaceSafeDirectories = BuildGitCliSafeDirectories(workspace.WorkingDirectory, sourcePath);
+        await RunGitCliAsync(
+            workspace.WorkingDirectory,
+            ["fetch", "origin"],
+            cancellationToken,
+            throwOnError: true,
+            safeDirectories: workspaceSafeDirectories);
+        await RunGitCliAsync(
+            workspace.WorkingDirectory,
+            ["checkout", "-B", workspace.BranchName, targetCommit],
+            cancellationToken,
+            throwOnError: true,
+            safeDirectories: workspaceSafeDirectories);
+        await RunGitCliAsync(
+            workspace.WorkingDirectory,
+            ["reset", "--hard", targetCommit],
+            cancellationToken,
+            throwOnError: true,
+            safeDirectories: workspaceSafeDirectories);
 
         workspace.LocalDirectoryImportModeUsed = LocalDirectoryImportMode.Copy;
     }
@@ -676,7 +713,10 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
             return false;
         }
 
-        var result = RunGitCli(path, ["rev-parse", "--show-toplevel"]);
+        var result = RunGitCli(
+            path,
+            ["rev-parse", "--show-toplevel"],
+            BuildGitCliSafeDirectories(path));
         if (result.ExitCode != 0)
         {
             reason = $"git rev-parse --show-toplevel failed with exit {result.ExitCode}: {result.Error}";
@@ -697,13 +737,17 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
     private async Task<string?> GetGitCliBranchHeadCommitAsync(
         string sourcePath,
         string branchName,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IReadOnlyList<string>? safeDirectories = null)
     {
+        safeDirectories ??= BuildGitCliSafeDirectories(sourcePath);
+
         var localResult = await RunGitCliAsync(
             sourcePath,
             ["rev-parse", "--verify", $"{branchName}^{{commit}}"],
             cancellationToken,
-            throwOnError: false);
+            throwOnError: false,
+            safeDirectories: safeDirectories);
         if (localResult.ExitCode == 0)
         {
             return localResult.Output.Trim();
@@ -713,7 +757,8 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
             sourcePath,
             ["rev-parse", "--verify", $"origin/{branchName}^{{commit}}"],
             cancellationToken,
-            throwOnError: false);
+            throwOnError: false,
+            safeDirectories: safeDirectories);
         if (remoteResult.ExitCode == 0)
         {
             return remoteResult.Output.Trim();
@@ -728,10 +773,11 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
     private async Task<bool> IsValidGitCliWorkspaceForSourceAsync(
         string workspacePath,
         string sourcePath,
+        IReadOnlyList<string> safeDirectories,
         CancellationToken cancellationToken)
     {
         return string.Equals(
-            await GetGitCliWorkspaceInvalidReasonAsync(workspacePath, sourcePath, cancellationToken),
+            await GetGitCliWorkspaceInvalidReasonAsync(workspacePath, sourcePath, safeDirectories, cancellationToken),
             "workspace is an exact Git workdir and origin matches source",
             StringComparison.Ordinal);
     }
@@ -739,6 +785,7 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
     private async Task<string> GetGitCliWorkspaceInvalidReasonAsync(
         string workspacePath,
         string sourcePath,
+        IReadOnlyList<string> safeDirectories,
         CancellationToken cancellationToken)
     {
         if (!Directory.Exists(workspacePath))
@@ -750,7 +797,8 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
             workspacePath,
             ["rev-parse", "--show-toplevel"],
             cancellationToken,
-            throwOnError: false);
+            throwOnError: false,
+            safeDirectories: safeDirectories);
         if (topLevelResult.ExitCode != 0)
         {
             return $"git rev-parse --show-toplevel failed with exit {topLevelResult.ExitCode}: {topLevelResult.Error}";
@@ -766,7 +814,8 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
             workspacePath,
             ["remote", "get-url", "origin"],
             cancellationToken,
-            throwOnError: false);
+            throwOnError: false,
+            safeDirectories: safeDirectories);
         if (originResult.ExitCode != 0)
         {
             return $"git remote get-url origin failed with exit {originResult.ExitCode}: {originResult.Error}";
@@ -781,11 +830,17 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         return "workspace is an exact Git workdir and origin matches source";
     }
 
-    private GitCliResult RunGitCli(string workingDirectory, IReadOnlyList<string> arguments)
+    private GitCliResult RunGitCli(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<string>? safeDirectories = null)
     {
+        safeDirectories ??= [];
+        LogGitCliCommand(workingDirectory, arguments, safeDirectories);
+
         try
         {
-            using var process = StartGitCli(workingDirectory, arguments);
+            using var process = StartGitCli(workingDirectory, arguments, safeDirectories);
             if (process == null)
             {
                 return new GitCliResult(-1, string.Empty, "Failed to start git process");
@@ -806,9 +861,13 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         string workingDirectory,
         IReadOnlyList<string> arguments,
         CancellationToken cancellationToken,
-        bool throwOnError)
+        bool throwOnError,
+        IReadOnlyList<string>? safeDirectories = null)
     {
-        using var process = StartGitCli(workingDirectory, arguments);
+        safeDirectories ??= [];
+        LogGitCliCommand(workingDirectory, arguments, safeDirectories);
+
+        using var process = StartGitCli(workingDirectory, arguments, safeDirectories);
         if (process == null)
         {
             throw new InvalidOperationException("Failed to start git process");
@@ -831,7 +890,22 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         return result;
     }
 
-    private static Process? StartGitCli(string workingDirectory, IReadOnlyList<string> arguments)
+    private void LogGitCliCommand(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<string> safeDirectories)
+    {
+        _logger.LogInformation(
+            "Running git command. WorkingDirectory: {WorkingDirectory}, Arguments: {Arguments}, SafeDirectories: {SafeDirectories}",
+            workingDirectory,
+            string.Join(' ', arguments),
+            string.Join(", ", safeDirectories));
+    }
+
+    private static Process? StartGitCli(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<string> safeDirectories)
     {
         var startInfo = new ProcessStartInfo
         {
@@ -843,8 +917,11 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
             CreateNoWindow = true
         };
 
-        startInfo.ArgumentList.Add("-c");
-        startInfo.ArgumentList.Add("safe.directory=*");
+        foreach (var safeDirectory in safeDirectories.Where(path => !string.IsNullOrWhiteSpace(path)))
+        {
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add($"safe.directory={safeDirectory}");
+        }
 
         foreach (var argument in arguments)
         {
@@ -852,6 +929,112 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         }
 
         return Process.Start(startInfo);
+    }
+
+    private static IReadOnlyList<string> BuildGitCliSafeDirectories(params string[] paths)
+    {
+        var safeDirectories = new List<string>();
+        var seen = new HashSet<string>(GetPathComparison() == StringComparison.OrdinalIgnoreCase
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal);
+
+        foreach (var path in paths)
+        {
+            AddSafeDirectory(safeDirectories, seen, path);
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                continue;
+            }
+
+            var normalizedPath = NormalizeLocalPath(path);
+            var gitPath = Path.Combine(normalizedPath, ".git");
+            if (File.Exists(gitPath) || Directory.Exists(gitPath))
+            {
+                AddSafeDirectory(safeDirectories, seen, gitPath);
+            }
+
+            if (TryResolveGitDirPointer(gitPath, normalizedPath, out var gitDir))
+            {
+                AddSafeDirectory(safeDirectories, seen, gitDir);
+
+                if (TryResolveGitCommonDir(gitDir, out var commonGitDir))
+                {
+                    AddSafeDirectory(safeDirectories, seen, commonGitDir);
+                }
+            }
+        }
+
+        return safeDirectories;
+    }
+
+    private static void AddSafeDirectory(
+        List<string> safeDirectories,
+        HashSet<string> seen,
+        string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        var normalizedPath = NormalizeLocalPath(path);
+        if (seen.Add(normalizedPath))
+        {
+            safeDirectories.Add(normalizedPath);
+        }
+    }
+
+    private static bool TryResolveGitDirPointer(
+        string gitPath,
+        string worktreePath,
+        out string gitDir)
+    {
+        gitDir = string.Empty;
+
+        if (!File.Exists(gitPath))
+        {
+            return false;
+        }
+
+        var firstLine = File.ReadLines(gitPath).FirstOrDefault();
+        if (firstLine == null ||
+            !firstLine.StartsWith("gitdir:", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var value = firstLine["gitdir:".Length..].Trim();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        gitDir = Path.IsPathRooted(value)
+            ? NormalizeLocalPath(value)
+            : NormalizeLocalPath(Path.Combine(worktreePath, value));
+        return true;
+    }
+
+    private static bool TryResolveGitCommonDir(string gitDir, out string commonGitDir)
+    {
+        commonGitDir = string.Empty;
+        var commonDirPath = Path.Combine(gitDir, "commondir");
+        if (!File.Exists(commonDirPath))
+        {
+            return false;
+        }
+
+        var value = File.ReadLines(commonDirPath).FirstOrDefault()?.Trim();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        commonGitDir = Path.IsPathRooted(value)
+            ? NormalizeLocalPath(value)
+            : NormalizeLocalPath(Path.Combine(gitDir, value));
+        return true;
     }
 
     private void DeleteWorkspaceDirectoryWithinRepositoryRoot(string workspacePath, string sourcePath)

--- a/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
+++ b/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
@@ -95,7 +95,7 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
                 }, cancellationToken);
             }
 
-            return await GetGitCliBranchHeadCommitAsync(localGitSource.RepositoryPath, branchName, cancellationToken);
+            return (await GetGitCliBranchHeadCommitAsync(localGitSource.RepositoryPath, branchName, cancellationToken))?.CommitId;
         }
 
         if (sourceInfo.SourceType == RepositorySourceType.LocalDirectory)
@@ -459,7 +459,7 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         var workspaceSafeDirectories = BuildGitCliSafeDirectories(workspace.WorkingDirectory, sourcePath);
         var sourceUploadPackArgument = BuildGitCliUploadPackArgument(sourceSafeDirectories);
 
-        var targetCommit = await GetGitCliBranchHeadCommitAsync(
+        var targetBranch = await GetGitCliBranchHeadCommitAsync(
                 sourcePath,
                 workspace.BranchName,
                 cancellationToken,
@@ -468,8 +468,8 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
                 $"Branch '{workspace.BranchName}' not found in local git source: {sourcePath}");
 
         _logger.LogInformation(
-            "Resolved local git source branch via git CLI. SourcePath: {SourcePath}, Branch: {Branch}, Commit: {CommitId}",
-            sourcePath, workspace.BranchName, targetCommit);
+            "Resolved local git source branch via git CLI. SourcePath: {SourcePath}, Branch: {Branch}, SourceRef: {SourceRef}, FetchRefSpec: {FetchRefSpec}, Commit: {CommitId}",
+            sourcePath, workspace.BranchName, targetBranch.SourceRef, targetBranch.FetchRefSpec, targetBranch.CommitId);
 
         if (await IsValidGitCliWorkspaceForSourceAsync(
                 workspace.WorkingDirectory,
@@ -477,12 +477,12 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
                 workspaceSafeDirectories,
                 cancellationToken))
         {
-            await RunGitCliAsync(
+            await FetchGitCliBranchAsync(
                 workspace.WorkingDirectory,
-                ["fetch", sourceUploadPackArgument, "origin"],
-                cancellationToken,
-                throwOnError: true,
-                safeDirectories: workspaceSafeDirectories);
+                sourceUploadPackArgument,
+                targetBranch,
+                workspaceSafeDirectories,
+                cancellationToken);
         }
         else
         {
@@ -513,21 +513,27 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         }
 
         workspaceSafeDirectories = BuildGitCliSafeDirectories(workspace.WorkingDirectory, sourcePath);
+        await FetchGitCliBranchAsync(
+            workspace.WorkingDirectory,
+            sourceUploadPackArgument,
+            targetBranch,
+            workspaceSafeDirectories,
+            cancellationToken);
+        await EnsureGitCliWorkspaceHasCommitAsync(
+            workspace.WorkingDirectory,
+            targetBranch.CommitId,
+            workspaceSafeDirectories,
+            cancellationToken,
+            targetBranch.FetchRefSpec);
         await RunGitCliAsync(
             workspace.WorkingDirectory,
-            ["fetch", sourceUploadPackArgument, "origin"],
+            ["checkout", "-B", workspace.BranchName, targetBranch.CommitId],
             cancellationToken,
             throwOnError: true,
             safeDirectories: workspaceSafeDirectories);
         await RunGitCliAsync(
             workspace.WorkingDirectory,
-            ["checkout", "-B", workspace.BranchName, targetCommit],
-            cancellationToken,
-            throwOnError: true,
-            safeDirectories: workspaceSafeDirectories);
-        await RunGitCliAsync(
-            workspace.WorkingDirectory,
-            ["reset", "--hard", targetCommit],
+            ["reset", "--hard", targetBranch.CommitId],
             cancellationToken,
             throwOnError: true,
             safeDirectories: workspaceSafeDirectories);
@@ -742,7 +748,7 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         return true;
     }
 
-    private async Task<string?> GetGitCliBranchHeadCommitAsync(
+    private async Task<GitCliBranchHead?> GetGitCliBranchHeadCommitAsync(
         string sourcePath,
         string branchName,
         CancellationToken cancellationToken,
@@ -752,30 +758,98 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
 
         var localResult = await RunGitCliAsync(
             sourcePath,
-            ["rev-parse", "--verify", $"{branchName}^{{commit}}"],
+            ["rev-parse", "--verify", $"refs/heads/{branchName}^{{commit}}"],
             cancellationToken,
             throwOnError: false,
             safeDirectories: safeDirectories);
         if (localResult.ExitCode == 0)
         {
-            return localResult.Output.Trim();
+            return new GitCliBranchHead(
+                localResult.Output.Trim(),
+                $"refs/heads/{branchName}",
+                $"+refs/heads/{branchName}:refs/remotes/origin/{branchName}");
         }
 
         var remoteResult = await RunGitCliAsync(
             sourcePath,
-            ["rev-parse", "--verify", $"origin/{branchName}^{{commit}}"],
+            ["rev-parse", "--verify", $"refs/remotes/origin/{branchName}^{{commit}}"],
             cancellationToken,
             throwOnError: false,
             safeDirectories: safeDirectories);
         if (remoteResult.ExitCode == 0)
         {
-            return remoteResult.Output.Trim();
+            return new GitCliBranchHead(
+                remoteResult.Output.Trim(),
+                $"refs/remotes/origin/{branchName}",
+                $"+refs/remotes/origin/{branchName}:refs/remotes/origin/{branchName}");
+        }
+
+        var matchingRemoteResult = await RunGitCliAsync(
+            sourcePath,
+            ["rev-parse", "--verify", $"refs/remotes/{branchName}^{{commit}}"],
+            cancellationToken,
+            throwOnError: false,
+            safeDirectories: safeDirectories);
+        if (matchingRemoteResult.ExitCode == 0)
+        {
+            return new GitCliBranchHead(
+                matchingRemoteResult.Output.Trim(),
+                $"refs/remotes/{branchName}",
+                $"+refs/remotes/{branchName}:refs/remotes/origin/{branchName}");
         }
 
         _logger.LogWarning(
-            "Unable to resolve local git source branch via git CLI. SourcePath: {SourcePath}, Branch: {Branch}, LocalError: {LocalError}, RemoteError: {RemoteError}",
-            sourcePath, branchName, localResult.Error, remoteResult.Error);
+            "Unable to resolve local git source branch via git CLI. SourcePath: {SourcePath}, Branch: {Branch}, LocalError: {LocalError}, OriginRemoteError: {OriginRemoteError}, MatchingRemoteError: {MatchingRemoteError}",
+            sourcePath, branchName, localResult.Error, remoteResult.Error, matchingRemoteResult.Error);
         return null;
+    }
+
+    private async Task FetchGitCliBranchAsync(
+        string workspacePath,
+        string sourceUploadPackArgument,
+        GitCliBranchHead targetBranch,
+        IReadOnlyList<string> safeDirectories,
+        CancellationToken cancellationToken)
+    {
+        await RunGitCliAsync(
+            workspacePath,
+            ["fetch", sourceUploadPackArgument, "origin", targetBranch.FetchRefSpec],
+            cancellationToken,
+            throwOnError: true,
+            safeDirectories: safeDirectories);
+    }
+
+    private async Task EnsureGitCliWorkspaceHasCommitAsync(
+        string workspacePath,
+        string targetCommit,
+        IReadOnlyList<string> safeDirectories,
+        CancellationToken cancellationToken,
+        string fetchRefSpec)
+    {
+        var result = await RunGitCliAsync(
+            workspacePath,
+            ["cat-file", "-t", targetCommit],
+            cancellationToken,
+            throwOnError: false,
+            safeDirectories: safeDirectories);
+        if (result.ExitCode == 0 &&
+            string.Equals(result.Output.Trim(), "commit", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var showRef = await RunGitCliAsync(
+            workspacePath,
+            ["show-ref"],
+            cancellationToken,
+            throwOnError: false,
+            safeDirectories: safeDirectories);
+
+        throw new InvalidOperationException(
+            $"Fetched local git source ref but target commit is not available in workspace. " +
+            $"Workspace: {workspacePath}, Commit: {targetCommit}, FetchRefSpec: {fetchRefSpec}, " +
+            $"CatFileExitCode: {result.ExitCode}, CatFileOutput: {result.Output}, CatFileError: {result.Error}, " +
+            $"ShowRef: {showRef.Output}");
     }
 
     private async Task<bool> IsValidGitCliWorkspaceForSourceAsync(
@@ -1154,6 +1228,8 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
     }
 
     private readonly record struct LocalGitSource(string RepositoryPath, LocalGitAccessMode AccessMode);
+
+    private readonly record struct GitCliBranchHead(string CommitId, string SourceRef, string FetchRefSpec);
 
     private readonly record struct GitCliResult(int ExitCode, string Output, string Error);
 

--- a/tests/OpenDeepWiki.Tests/Services/Repositories/RepositoryAnalyzerSourceTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/Repositories/RepositoryAnalyzerSourceTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Reflection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using OpenDeepWiki.Entities;
@@ -388,6 +389,38 @@ public class RepositoryAnalyzerSourceTests
         Assert.Equal("B branch", File.ReadAllText(Path.Combine(workspace.WorkingDirectory, "branch.txt")));
     }
 
+    [Fact]
+    public void BuildGitCliSafeDirectories_WhenSourceIsGitWorktree_IncludesWorktreeGitFileAndCommonGitDir()
+    {
+        var sourceRoot = CreateTempDirectory();
+        var worktreeRoot = CreateTempDirectory();
+        Directory.Delete(worktreeRoot);
+        CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "smart-hw/os_services_develop",
+            "smart-hw/rv1106_develop");
+        using (var sourceRepository = new GitRepository(sourceRoot))
+        {
+            sourceRepository.Worktrees.Add(
+                "smart-hw/os_services_develop",
+                "source-worktree",
+                worktreeRoot,
+                isLocked: false);
+        }
+
+        var gitFile = Path.Combine(worktreeRoot, ".git");
+        var gitDir = ResolveGitDirPointerForTest(gitFile, worktreeRoot);
+        var commonGitDir = ResolveCommonGitDirForTest(gitDir);
+        var safeDirectories = InvokeBuildGitCliSafeDirectories(worktreeRoot)
+            .Select(NormalizePath)
+            .ToArray();
+
+        Assert.Contains(NormalizePath(worktreeRoot), safeDirectories);
+        Assert.Contains(NormalizePath(gitFile), safeDirectories);
+        Assert.Contains(NormalizePath(gitDir), safeDirectories);
+        Assert.Contains(NormalizePath(commonGitDir), safeDirectories);
+    }
+
     private static RepositoryAnalyzer CreateAnalyzer(string repositoriesRoot, RepositoryAnalyzerOptions? options = null)
     {
         return new RepositoryAnalyzer(
@@ -397,6 +430,33 @@ public class RepositoryAnalyzerSourceTests
                 AllowedLocalPathRoots = []
             }),
             NullLogger<RepositoryAnalyzer>.Instance);
+    }
+
+    private static IReadOnlyList<string> InvokeBuildGitCliSafeDirectories(params string[] paths)
+    {
+        var method = typeof(RepositoryAnalyzer).GetMethod(
+            "BuildGitCliSafeDirectories",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return Assert.IsAssignableFrom<IReadOnlyList<string>>(method.Invoke(null, [paths]));
+    }
+
+    private static string ResolveGitDirPointerForTest(string gitFile, string worktreePath)
+    {
+        var firstLine = File.ReadLines(gitFile).First();
+        Assert.StartsWith("gitdir:", firstLine, StringComparison.OrdinalIgnoreCase);
+        var gitDir = firstLine["gitdir:".Length..].Trim();
+        return Path.IsPathRooted(gitDir)
+            ? NormalizePath(gitDir)
+            : NormalizePath(Path.Combine(worktreePath, gitDir));
+    }
+
+    private static string ResolveCommonGitDirForTest(string gitDir)
+    {
+        var commonDir = File.ReadLines(Path.Combine(gitDir, "commondir")).First().Trim();
+        return Path.IsPathRooted(commonDir)
+            ? NormalizePath(commonDir)
+            : NormalizePath(Path.Combine(gitDir, commonDir));
     }
 
     private static string CreateTempDirectory()

--- a/tests/OpenDeepWiki.Tests/Services/Repositories/RepositoryAnalyzerSourceTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/Repositories/RepositoryAnalyzerSourceTests.cs
@@ -421,6 +421,28 @@ public class RepositoryAnalyzerSourceTests
         Assert.Contains(NormalizePath(commonGitDir), safeDirectories);
     }
 
+    [Fact]
+    public void BuildGitCliUploadPackArgument_IncludesSafeDirectoriesBeforeUploadPack()
+    {
+        var sourceRoot = NormalizePath(Path.Combine(CreateTempDirectory(), "source with space"));
+        var gitDir = NormalizePath(Path.Combine(sourceRoot, ".git"));
+        var argument = InvokeBuildGitCliUploadPackArgument([sourceRoot, gitDir]);
+        var processArguments = InvokeBuildGitCliProcessArguments(
+            ["clone", "--no-local", argument, "--no-checkout", sourceRoot, "/tmp/target"],
+            [sourceRoot, gitDir]);
+
+        Assert.Contains($"-c 'safe.directory={sourceRoot}'", argument);
+        Assert.Contains($"-c 'safe.directory={gitDir}'", argument);
+        Assert.EndsWith(" upload-pack", argument);
+        Assert.Equal("-c", processArguments[0]);
+        Assert.Equal($"safe.directory={sourceRoot}", processArguments[1]);
+        Assert.Equal("-c", processArguments[2]);
+        Assert.Equal($"safe.directory={gitDir}", processArguments[3]);
+        Assert.Equal("clone", processArguments[4]);
+        Assert.Equal("--no-local", processArguments[5]);
+        Assert.Equal(argument, processArguments[6]);
+    }
+
     private static RepositoryAnalyzer CreateAnalyzer(string repositoriesRoot, RepositoryAnalyzerOptions? options = null)
     {
         return new RepositoryAnalyzer(
@@ -439,6 +461,28 @@ public class RepositoryAnalyzerSourceTests
             BindingFlags.NonPublic | BindingFlags.Static);
         Assert.NotNull(method);
         return Assert.IsAssignableFrom<IReadOnlyList<string>>(method.Invoke(null, [paths]));
+    }
+
+    private static string InvokeBuildGitCliUploadPackArgument(IReadOnlyList<string> safeDirectories)
+    {
+        var method = typeof(RepositoryAnalyzer).GetMethod(
+            "BuildGitCliUploadPackArgument",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return Assert.IsType<string>(method.Invoke(null, [safeDirectories]));
+    }
+
+    private static string[] InvokeBuildGitCliProcessArguments(
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<string> safeDirectories)
+    {
+        var method = typeof(RepositoryAnalyzer).GetMethod(
+            "BuildGitCliProcessArguments",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        var result = Assert.IsAssignableFrom<IEnumerable<string>>(
+            method.Invoke(null, [arguments, safeDirectories]));
+        return result.ToArray();
     }
 
     private static string ResolveGitDirPointerForTest(string gitFile, string worktreePath)

--- a/tests/OpenDeepWiki.Tests/Services/Repositories/RepositoryAnalyzerSourceTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/Repositories/RepositoryAnalyzerSourceTests.cs
@@ -169,6 +169,45 @@ public class RepositoryAnalyzerSourceTests
         Assert.NotEqual(aWorkspace.WorkingDirectory, bWorkspace.WorkingDirectory);
     }
 
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenLocalDirectorySourceIsGitRepository_UsesTargetBranchHead()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var sourceRoot = CreateTempDirectory();
+        var (aCommit, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "smart-hw/os_services_develop",
+            "smart-hw/rv1106_develop");
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [Path.GetDirectoryName(sourceRoot)!]
+            });
+        var repository = new Repository
+        {
+            Id = Guid.NewGuid().ToString(),
+            OwnerUserId = Guid.NewGuid().ToString(),
+            OrgName = "YD_HW/services",
+            RepoName = "youdao-input-event-monitor",
+            GitUrl = RepositorySource.EncodeLocalDirectoryPath(sourceRoot)
+        };
+
+        var aWorkspace = await analyzer.PrepareWorkspaceAsync(repository, "smart-hw/os_services_develop");
+        var bWorkspace = await analyzer.PrepareWorkspaceAsync(repository, "smart-hw/rv1106_develop");
+        var bRemoteHead = await analyzer.GetRemoteBranchHeadCommitAsync(repository, "smart-hw/rv1106_develop");
+
+        Assert.Equal(RepositorySourceType.LocalDirectory, bWorkspace.SourceType);
+        Assert.True(bWorkspace.SupportsIncrementalUpdates);
+        Assert.Equal(aCommit, aWorkspace.CommitId);
+        Assert.Equal("A branch", File.ReadAllText(Path.Combine(aWorkspace.WorkingDirectory, "branch.txt")));
+        Assert.Equal(bCommit, bWorkspace.CommitId);
+        Assert.Equal(bCommit, bRemoteHead);
+        Assert.Equal("B branch", File.ReadAllText(Path.Combine(bWorkspace.WorkingDirectory, "branch.txt")));
+        Assert.NotEqual(aWorkspace.WorkingDirectory, bWorkspace.WorkingDirectory);
+    }
+
     private static RepositoryAnalyzer CreateAnalyzer(string repositoriesRoot, RepositoryAnalyzerOptions? options = null)
     {
         return new RepositoryAnalyzer(

--- a/tests/OpenDeepWiki.Tests/Services/Repositories/RepositoryAnalyzerSourceTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/Repositories/RepositoryAnalyzerSourceTests.cs
@@ -443,6 +443,64 @@ public class RepositoryAnalyzerSourceTests
         Assert.Equal(argument, processArguments[6]);
     }
 
+    [Fact]
+    public async Task GetGitCliBranchHeadCommitAsync_WhenLocalBranchExists_ReturnsExplicitFetchRefSpec()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var sourceRoot = CreateTempDirectory();
+        var (_, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "smart-hw/os_services_develop",
+            "smart-hw/rv1106_develop");
+        var analyzer = CreateAnalyzer(repositoriesRoot);
+
+        var result = await InvokeGetGitCliBranchHeadCommitAsync(
+            analyzer,
+            sourceRoot,
+            "smart-hw/rv1106_develop");
+
+        Assert.NotNull(result);
+        Assert.Equal(bCommit, GetReflectedStringProperty(result, "CommitId"));
+        Assert.Equal("refs/heads/smart-hw/rv1106_develop", GetReflectedStringProperty(result, "SourceRef"));
+        Assert.Equal(
+            "+refs/heads/smart-hw/rv1106_develop:refs/remotes/origin/smart-hw/rv1106_develop",
+            GetReflectedStringProperty(result, "FetchRefSpec"));
+    }
+
+    [Fact]
+    public async Task GetGitCliBranchHeadCommitAsync_WhenMatchingRemoteRefExists_ReturnsRemoteFetchRefSpec()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var sourceRoot = CreateTempDirectory();
+        var (aCommit, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "smart-hw/os_services_develop",
+            "smart-hw/rv1106_develop");
+        using (var sourceRepository = new GitRepository(sourceRoot))
+        {
+            sourceRepository.Refs.Add(
+                "refs/remotes/smart-hw/rv1106_develop",
+                bCommit,
+                true);
+            GitCommands.Checkout(sourceRepository, (LibGit2Sharp.Commit)sourceRepository.Lookup(aCommit));
+            sourceRepository.Branches.Remove("smart-hw/rv1106_develop");
+        }
+
+        var analyzer = CreateAnalyzer(repositoriesRoot);
+
+        var result = await InvokeGetGitCliBranchHeadCommitAsync(
+            analyzer,
+            sourceRoot,
+            "smart-hw/rv1106_develop");
+
+        Assert.NotNull(result);
+        Assert.Equal(bCommit, GetReflectedStringProperty(result, "CommitId"));
+        Assert.Equal("refs/remotes/smart-hw/rv1106_develop", GetReflectedStringProperty(result, "SourceRef"));
+        Assert.Equal(
+            "+refs/remotes/smart-hw/rv1106_develop:refs/remotes/origin/smart-hw/rv1106_develop",
+            GetReflectedStringProperty(result, "FetchRefSpec"));
+    }
+
     private static RepositoryAnalyzer CreateAnalyzer(string repositoriesRoot, RepositoryAnalyzerOptions? options = null)
     {
         return new RepositoryAnalyzer(
@@ -483,6 +541,27 @@ public class RepositoryAnalyzerSourceTests
         var result = Assert.IsAssignableFrom<IEnumerable<string>>(
             method.Invoke(null, [arguments, safeDirectories]));
         return result.ToArray();
+    }
+
+    private static async Task<object?> InvokeGetGitCliBranchHeadCommitAsync(
+        RepositoryAnalyzer analyzer,
+        string sourcePath,
+        string branchName)
+    {
+        var method = typeof(RepositoryAnalyzer).GetMethod(
+            "GetGitCliBranchHeadCommitAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        var task = Assert.IsAssignableFrom<Task>(method.Invoke(
+            analyzer,
+            [sourcePath, branchName, CancellationToken.None, null]));
+        await task;
+        return task.GetType().GetProperty("Result")?.GetValue(task);
+    }
+
+    private static string GetReflectedStringProperty(object value, string propertyName)
+    {
+        return Assert.IsType<string>(value.GetType().GetProperty(propertyName)?.GetValue(value));
     }
 
     private static string ResolveGitDirPointerForTest(string gitFile, string worktreePath)

--- a/tests/OpenDeepWiki.Tests/Services/Repositories/RepositoryAnalyzerSourceTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/Repositories/RepositoryAnalyzerSourceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using OpenDeepWiki.Entities;
 using OpenDeepWiki.Services.Repositories;
 using Xunit;
+using GitCloneOptions = LibGit2Sharp.CloneOptions;
 using GitCommitOptions = LibGit2Sharp.CommitOptions;
 using GitCommands = LibGit2Sharp.Commands;
 using GitRepository = LibGit2Sharp.Repository;
@@ -208,6 +209,185 @@ public class RepositoryAnalyzerSourceTests
         Assert.NotEqual(aWorkspace.WorkingDirectory, bWorkspace.WorkingDirectory);
     }
 
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenWorkspaceIsPlainDirectoryInsideParentGitRepo_ReclonesTargetBranch()
+    {
+        var parentRoot = CreateTempDirectory();
+        GitRepository.Init(parentRoot);
+        var repositoriesRoot = Path.Combine(parentRoot, "data");
+        var sourceRoot = CreateTempDirectory();
+        var (_, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "smart-hw/os_services_develop",
+            "smart-hw/rv1106_develop");
+        var pollutedWorkspace = GetExpectedWorkspacePath(
+            repositoriesRoot,
+            "YD_HW/services",
+            "youdao-input-event-monitor",
+            "smart-hw/rv1106_develop");
+        Directory.CreateDirectory(pollutedWorkspace);
+        File.WriteAllText(Path.Combine(pollutedWorkspace, "branch.txt"), "polluted parent repository content");
+
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [Path.GetDirectoryName(sourceRoot)!]
+            });
+        var repository = CreateLocalSourceRepository(sourceRoot);
+
+        var workspace = await analyzer.PrepareWorkspaceAsync(repository, "smart-hw/rv1106_develop");
+
+        Assert.Equal(bCommit, workspace.CommitId);
+        Assert.Equal("B branch", File.ReadAllText(Path.Combine(workspace.WorkingDirectory, "branch.txt")));
+        using var workspaceRepository = new GitRepository(workspace.WorkingDirectory);
+        Assert.Equal(NormalizePath(workspace.WorkingDirectory), NormalizePath(workspaceRepository.Info.WorkingDirectory));
+    }
+
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenWorkspaceHasInvalidGitDirectory_Reclones()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var sourceRoot = CreateTempDirectory();
+        var (_, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "smart-hw/os_services_develop",
+            "smart-hw/rv1106_develop");
+        var invalidWorkspace = GetExpectedWorkspacePath(
+            repositoriesRoot,
+            "YD_HW/services",
+            "youdao-input-event-monitor",
+            "smart-hw/rv1106_develop");
+        Directory.CreateDirectory(Path.Combine(invalidWorkspace, ".git"));
+
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [Path.GetDirectoryName(sourceRoot)!]
+            });
+        var repository = CreateLocalSourceRepository(sourceRoot);
+
+        var workspace = await analyzer.PrepareWorkspaceAsync(repository, "smart-hw/rv1106_develop");
+
+        Assert.Equal(bCommit, workspace.CommitId);
+        Assert.Equal("B branch", File.ReadAllText(Path.Combine(workspace.WorkingDirectory, "branch.txt")));
+    }
+
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenWorkspaceOriginPointsAtDifferentSource_Reclones()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var rightSourceRoot = CreateTempDirectory();
+        var wrongSourceRoot = CreateTempDirectory();
+        var (_, rightBCommit) = CreateGitRepositoryWithBranches(
+            rightSourceRoot,
+            "smart-hw/os_services_develop",
+            "smart-hw/rv1106_develop",
+            bContent: "right B branch");
+        CreateGitRepositoryWithBranches(
+            wrongSourceRoot,
+            "smart-hw/os_services_develop",
+            "smart-hw/rv1106_develop",
+            bContent: "wrong B branch");
+        var workspacePath = GetExpectedWorkspacePath(
+            repositoriesRoot,
+            "YD_HW/services",
+            "youdao-input-event-monitor",
+            "smart-hw/rv1106_develop");
+        GitRepository.Clone(
+            wrongSourceRoot,
+            workspacePath,
+            new GitCloneOptions { BranchName = "smart-hw/rv1106_develop" });
+
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [Path.GetDirectoryName(rightSourceRoot)!]
+            });
+        var repository = CreateLocalSourceRepository(rightSourceRoot);
+
+        var workspace = await analyzer.PrepareWorkspaceAsync(repository, "smart-hw/rv1106_develop");
+
+        Assert.Equal(rightBCommit, workspace.CommitId);
+        Assert.Equal("right B branch", File.ReadAllText(Path.Combine(workspace.WorkingDirectory, "branch.txt")));
+        using var workspaceRepository = new GitRepository(workspace.WorkingDirectory);
+        Assert.Equal(NormalizePath(rightSourceRoot), NormalizePath(workspaceRepository.Network.Remotes["origin"].Url));
+    }
+
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenLocalDirectorySourceIsGitRepoSubdirectory_DoesNotUseParentGitRepository()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var parentRoot = CreateTempDirectory();
+        GitRepository.Init(parentRoot);
+        using (var parentRepository = new GitRepository(parentRoot))
+        {
+            var signature = new GitSignature("OpenDeepWiki Tests", "tests@opendeepwiki.local", DateTimeOffset.UtcNow);
+            Directory.CreateDirectory(Path.Combine(parentRoot, "nested-source"));
+            File.WriteAllText(Path.Combine(parentRoot, "nested-source", "branch.txt"), "plain nested source");
+            GitCommands.Stage(parentRepository, "nested-source/branch.txt");
+            parentRepository.Commit("Parent commit", signature, signature, new GitCommitOptions());
+        }
+
+        var sourceSubdirectory = Path.Combine(parentRoot, "nested-source");
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [parentRoot]
+            });
+        var repository = CreateLocalSourceRepository(sourceSubdirectory);
+
+        var workspace = await analyzer.PrepareWorkspaceAsync(repository, "smart-hw/rv1106_develop");
+
+        Assert.False(workspace.SupportsIncrementalUpdates);
+        Assert.Equal(64, workspace.CommitId.Length);
+        Assert.Equal("plain nested source", File.ReadAllText(Path.Combine(workspace.WorkingDirectory, "branch.txt")));
+        Assert.False(Directory.Exists(Path.Combine(workspace.WorkingDirectory, ".git")));
+    }
+
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenLocalDirectorySourceIsGitWorktree_UsesTargetBranchHead()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var sourceRoot = CreateTempDirectory();
+        var worktreeRoot = CreateTempDirectory();
+        Directory.Delete(worktreeRoot);
+        var (_, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "smart-hw/os_services_develop",
+            "smart-hw/rv1106_develop");
+        using (var sourceRepository = new GitRepository(sourceRoot))
+        {
+            sourceRepository.Worktrees.Add(
+                "smart-hw/os_services_develop",
+                "source-worktree",
+                worktreeRoot,
+                isLocked: false);
+        }
+
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [Path.GetDirectoryName(worktreeRoot)!]
+            });
+        var repository = CreateLocalSourceRepository(worktreeRoot);
+
+        var workspace = await analyzer.PrepareWorkspaceAsync(repository, "smart-hw/rv1106_develop");
+
+        Assert.True(File.Exists(Path.Combine(worktreeRoot, ".git")));
+        Assert.Equal(bCommit, workspace.CommitId);
+        Assert.Equal("B branch", File.ReadAllText(Path.Combine(workspace.WorkingDirectory, "branch.txt")));
+    }
+
     private static RepositoryAnalyzer CreateAnalyzer(string repositoriesRoot, RepositoryAnalyzerOptions? options = null)
     {
         return new RepositoryAnalyzer(
@@ -241,16 +421,65 @@ public class RepositoryAnalyzerSourceTests
         }
     }
 
+    private static Repository CreateLocalSourceRepository(string sourceRoot)
+    {
+        return new Repository
+        {
+            Id = Guid.NewGuid().ToString(),
+            OwnerUserId = Guid.NewGuid().ToString(),
+            OrgName = "YD_HW/services",
+            RepoName = "youdao-input-event-monitor",
+            GitUrl = RepositorySource.EncodeLocalDirectoryPath(sourceRoot)
+        };
+    }
+
+    private static string GetExpectedWorkspacePath(
+        string repositoriesRoot,
+        string orgName,
+        string repositoryName,
+        string branchName)
+    {
+        return Path.Combine(
+            repositoriesRoot,
+            SanitizePathComponent(orgName),
+            SanitizePathComponent(repositoryName),
+            "branches",
+            SanitizePathComponent(branchName),
+            "tree");
+    }
+
+    private static string SanitizePathComponent(string component)
+    {
+        return component
+            .Replace('/', '_')
+            .Replace('\\', '_')
+            .Replace("..", "_")
+            .Trim();
+    }
+
+    private static string NormalizePath(string path)
+    {
+        if (Uri.TryCreate(path, UriKind.Absolute, out var uri) && uri.IsFile)
+        {
+            path = uri.LocalPath;
+        }
+
+        return Path.GetFullPath(path)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
     private static (string ACommit, string BCommit) CreateGitRepositoryWithBranches(
         string repositoryPath,
         string branchA,
-        string branchB)
+        string branchB,
+        string aContent = "A branch",
+        string bContent = "B branch")
     {
         GitRepository.Init(repositoryPath);
         using var repository = new GitRepository(repositoryPath);
         var signature = new GitSignature("OpenDeepWiki Tests", "tests@opendeepwiki.local", DateTimeOffset.UtcNow);
 
-        File.WriteAllText(Path.Combine(repositoryPath, "branch.txt"), "A branch");
+        File.WriteAllText(Path.Combine(repositoryPath, "branch.txt"), aContent);
         GitCommands.Stage(repository, "branch.txt");
         var commitOptions = new GitCommitOptions();
         var aCommit = repository.Commit("A branch", signature, signature, commitOptions);
@@ -258,7 +487,7 @@ public class RepositoryAnalyzerSourceTests
 
         var bBranch = repository.Branches.Add(branchB, aCommit);
         GitCommands.Checkout(repository, bBranch);
-        File.WriteAllText(Path.Combine(repositoryPath, "branch.txt"), "B branch");
+        File.WriteAllText(Path.Combine(repositoryPath, "branch.txt"), bContent);
         GitCommands.Stage(repository, "branch.txt");
         var bCommit = repository.Commit("B branch", signature, signature, commitOptions);
 


### PR DESCRIPTION
## Summary

- Detect `local::...` repository sources that are Git working trees or worktrees.
- Prepare those local Git sources through branch-aware checkout/reset logic so branch generation uses the requested branch HEAD instead of a directory snapshot hash.
- Keep plain non-Git local directory sources on the existing copy/link and snapshot-hash behavior.
- Add regression coverage for branch-aware local Git source preparation.

## Validation

- `dotnet build OpenDeepWiki.sln --no-restore`
- `dotnet test tests/OpenDeepWiki.Tests/OpenDeepWiki.Tests.csproj --no-build --filter "FullyQualifiedName~RepositoryAnalyzerSourceTests"`
- `dotnet test tests/OpenDeepWiki.Tests/OpenDeepWiki.Tests.csproj --no-build --filter "FullyQualifiedName~BranchGenerationTaskServiceTests|FullyQualifiedName~BranchGenerationWorkerTests"`
- `git diff --check origin/main..HEAD`

RAM-36 follow-up for merged PR #375.
