### PR TITLE
Fix local Git source branch preparation

### DIFF
--- a/src/OpenDeepWiki/Services/Repositories/IncrementalUpdateWorker.cs
+++ b/src/OpenDeepWiki/Services/Repositories/IncrementalUpdateWorker.cs
@@ -292,7 +292,7 @@ public class IncrementalUpdateWorker : BackgroundService
                 .Where(b => b.RepositoryId == repository.Id && !b.IsDeleted)
                 .ToListAsync(stoppingToken);
 
-            var isGitRepository = RepositorySource.IsGit(repository.GitUrl);
+            var sourceInfo = RepositorySource.Parse(repository.GitUrl);
             var saveChanges = false;
 
             foreach (var branch in branches)
@@ -329,13 +329,6 @@ public class IncrementalUpdateWorker : BackgroundService
                     continue;
                 }
 
-                if (!isGitRepository)
-                {
-                    CreateScheduledTask(context, repository, branch, branch.LastCommitId, null);
-                    saveChanges = true;
-                    continue;
-                }
-
                 string? remoteCommitId;
                 try
                 {
@@ -357,11 +350,18 @@ public class IncrementalUpdateWorker : BackgroundService
 
                 if (string.IsNullOrWhiteSpace(remoteCommitId))
                 {
-                    _logger.LogWarning(
-                        "Remote HEAD was not found. Repository: {Org}/{Repo}, Branch: {Branch}",
-                        repository.OrgName,
-                        repository.RepoName,
-                        branch.BranchName);
+                    if (sourceInfo.SourceType == RepositorySourceType.Git)
+                    {
+                        _logger.LogWarning(
+                            "Remote HEAD was not found. Repository: {Org}/{Repo}, Branch: {Branch}",
+                            repository.OrgName,
+                            repository.RepoName,
+                            branch.BranchName);
+                        continue;
+                    }
+
+                    CreateScheduledTask(context, repository, branch, branch.LastCommitId, null);
+                    saveChanges = true;
                     continue;
                 }
 
@@ -373,6 +373,13 @@ public class IncrementalUpdateWorker : BackgroundService
                         repository.RepoName,
                         branch.BranchName,
                         remoteCommitId);
+                    continue;
+                }
+
+                if (ShouldNormalizeSnapshotBaseline(sourceInfo, branch.LastCommitId, remoteCommitId))
+                {
+                    NormalizeSnapshotBaseline(repository, branch, remoteCommitId);
+                    saveChanges = true;
                     continue;
                 }
 
@@ -395,6 +402,46 @@ public class IncrementalUpdateWorker : BackgroundService
                 "Failed to create scheduled update tasks. Repository: {Org}/{Repo}",
                 repository.OrgName, repository.RepoName);
         }
+    }
+
+    private void NormalizeSnapshotBaseline(
+        Repository repository,
+        RepositoryBranch branch,
+        string remoteCommitId)
+    {
+        var previousCommitId = branch.LastCommitId;
+        branch.LastCommitId = remoteCommitId;
+        branch.UpdatedAt = DateTime.UtcNow;
+
+        _logger.LogInformation(
+            "Normalized scheduled incremental baseline without creating a task. Repository: {Org}/{Repo}, Branch: {Branch}, PreviousCommit: {PreviousCommit}, CurrentCommit: {CurrentCommit}",
+            repository.OrgName,
+            repository.RepoName,
+            branch.BranchName,
+            previousCommitId,
+            remoteCommitId);
+    }
+
+    private static bool ShouldNormalizeSnapshotBaseline(
+        RepositorySourceInfo sourceInfo,
+        string? previousCommitId,
+        string remoteCommitId)
+    {
+        return sourceInfo.SourceType == RepositorySourceType.LocalDirectory &&
+               IsGitCommitId(remoteCommitId) &&
+               IsDirectorySnapshotId(previousCommitId);
+    }
+
+    private static bool IsGitCommitId(string? commitId)
+    {
+        return commitId is { Length: 40 } &&
+               commitId.All(Uri.IsHexDigit);
+    }
+
+    private static bool IsDirectorySnapshotId(string? commitId)
+    {
+        return commitId is { Length: 64 } &&
+               commitId.All(Uri.IsHexDigit);
     }
 
     private void CreateScheduledTask(

--- a/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
+++ b/src/OpenDeepWiki/Services/Repositories/RepositoryAnalyzer.cs
@@ -80,6 +80,48 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         }
 
         var sourceInfo = RepositorySource.Parse(repository.GitUrl);
+        var exactFailureReason = "not evaluated";
+        if (sourceInfo.SourceType == RepositorySourceType.LocalDirectory &&
+            TryResolveLocalGitSource(sourceInfo.Location, out var localGitSource, out exactFailureReason))
+        {
+            if (localGitSource.AccessMode == LocalGitAccessMode.LibGit2)
+            {
+                using (var localRepository = new GitRepository(localGitSource.RepositoryPath))
+                {
+                    var commitId = await Task.Run(() =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        return ResolveLocalSourceBranchTip(localRepository, branchName)?.Sha;
+                    }, cancellationToken);
+
+                    if (!string.IsNullOrWhiteSpace(commitId))
+                    {
+                        return commitId;
+                    }
+
+                    if (!TryResolveLocalSourceMatchingRemoteRefTip(localRepository, branchName, out _))
+                    {
+                        return null;
+                    }
+                }
+
+                return (await GetGitCliBranchHeadCommitAsync(
+                    localGitSource.RepositoryPath,
+                    branchName,
+                    cancellationToken))?.CommitId;
+            }
+
+            return (await GetGitCliBranchHeadCommitAsync(localGitSource.RepositoryPath, branchName, cancellationToken))?.CommitId;
+        }
+
+        if (sourceInfo.SourceType == RepositorySourceType.LocalDirectory)
+        {
+            _logger.LogInformation(
+                "Local source remote HEAD lookup skipped because decoded source is not an exact Git source. Repository: {Org}/{Repo}, Branch: {Branch}, SourcePath: {SourcePath}, Reason: {Reason}",
+                repository.OrgName, repository.RepoName, branchName, sourceInfo.Location, exactFailureReason);
+        }
+
         if (sourceInfo.SourceType != RepositorySourceType.Git)
         {
             _logger.LogDebug(
@@ -134,8 +176,9 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         };
 
         _logger.LogInformation(
-            "Preparing workspace. Repository: {Org}/{Repo}, Branch: {Branch}, WorkingDirectory: {Path}, PreviousCommit: {PreviousCommit}",
-            workspace.Organization, workspace.RepositoryName, branchName, 
+            "Preparing workspace. Repository: {Org}/{Repo}, Branch: {Branch}, SourceType: {SourceType}, SourceLocation: {SourceLocation}, WorkingDirectory: {Path}, PreviousCommit: {PreviousCommit}",
+            workspace.Organization, workspace.RepositoryName, branchName,
+            workspace.SourceType, workspace.SourceLocation,
             workspace.WorkingDirectory, previousCommitId ?? "none");
 
         // Ensure the parent directory exists
@@ -176,8 +219,21 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
             await PrepareArchiveWorkspaceAsync(workspace, cancellationToken);
             workspace.CommitId = ComputeDirectorySnapshotId(workspace.WorkingDirectory);
         }
+        else if (TryResolveLocalGitSource(workspace.SourceLocation, out var localGitSource, out var localGitFailureReason))
+        {
+            await PrepareLocalGitWorkspaceAsync(workspace, localGitSource, cancellationToken);
+            workspace.CommitId = GetHeadCommitId(workspace.WorkingDirectory);
+            workspace.SupportsIncrementalUpdates = true;
+        }
         else
         {
+            if (workspace.SourceType == RepositorySourceType.LocalDirectory)
+            {
+                _logger.LogWarning(
+                    "Decoded local source is not an exact Git source; falling back to local directory snapshot. SourcePath: {SourcePath}, Branch: {Branch}, WorkingDirectory: {Path}, Reason: {Reason}",
+                    workspace.SourceLocation, workspace.BranchName, workspace.WorkingDirectory, localGitFailureReason);
+            }
+
             await PrepareLocalDirectoryWorkspaceAsync(workspace, cancellationToken);
             workspace.CommitId = ComputeDirectorySnapshotId(workspace.WorkingDirectory);
         }
@@ -353,6 +409,175 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
         CopyDirectory(workspace.SourceLocation, workspace.WorkingDirectory);
     }
 
+    private async Task PrepareLocalGitWorkspaceAsync(
+        RepositoryWorkspace workspace,
+        LocalGitSource localGitSource,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(localGitSource.RepositoryPath) || !Directory.Exists(localGitSource.RepositoryPath))
+        {
+            throw new DirectoryNotFoundException($"Local git source not found: {localGitSource.RepositoryPath}");
+        }
+
+        _logger.LogInformation(
+            "Preparing local git workspace from target branch. SourcePath: {SourcePath}, Branch: {Branch}, TargetPath: {Path}, AccessMode: {AccessMode}",
+            localGitSource.RepositoryPath, workspace.BranchName, workspace.WorkingDirectory, localGitSource.AccessMode);
+
+        if (localGitSource.AccessMode == LocalGitAccessMode.GitCli)
+        {
+            await PrepareLocalGitWorkspaceWithCliAsync(workspace, localGitSource.RepositoryPath, cancellationToken);
+            return;
+        }
+
+        Commit? targetTip;
+        using (var sourceRepository = new GitRepository(localGitSource.RepositoryPath))
+        {
+            targetTip = ResolveLocalSourceBranchTip(sourceRepository, workspace.BranchName);
+            if (targetTip is null &&
+                TryResolveLocalSourceMatchingRemoteRefTip(sourceRepository, workspace.BranchName, out var matchingRemoteTip))
+            {
+                _logger.LogInformation(
+                    "Local git source branch only exists as a matching remote ref; routing workspace preparation through git CLI. SourcePath: {SourcePath}, Branch: {Branch}, SourceRef: {SourceRef}, Commit: {CommitId}",
+                    localGitSource.RepositoryPath,
+                    workspace.BranchName,
+                    $"refs/remotes/{workspace.BranchName}",
+                    matchingRemoteTip.Sha);
+
+                await PrepareLocalGitWorkspaceWithCliAsync(workspace, localGitSource.RepositoryPath, cancellationToken);
+                return;
+            }
+        }
+
+        if (targetTip is null)
+        {
+            throw new InvalidOperationException(
+                $"Branch '{workspace.BranchName}' not found in local git source: {localGitSource.RepositoryPath}");
+        }
+
+        _logger.LogInformation(
+            "Resolved local git source branch. SourcePath: {SourcePath}, Branch: {Branch}, Commit: {CommitId}",
+            localGitSource.RepositoryPath, workspace.BranchName, targetTip.Sha);
+
+        var originalGitUrl = workspace.GitUrl;
+        workspace.GitUrl = localGitSource.RepositoryPath;
+
+        try
+        {
+            if (IsValidWorkspaceForSource(workspace.WorkingDirectory, localGitSource.RepositoryPath, out var workspaceReason))
+            {
+                await PullRepositoryAsync(workspace, credentials: null, cancellationToken);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Existing local git workspace is missing, invalid, or points at a different source; recloning. SourcePath: {SourcePath}, Branch: {Branch}, TargetPath: {Path}, Reason: {Reason}",
+                    localGitSource.RepositoryPath, workspace.BranchName, workspace.WorkingDirectory, workspaceReason);
+
+                DeleteWorkspaceDirectoryWithinRepositoryRoot(workspace.WorkingDirectory, localGitSource.RepositoryPath);
+                await CloneRepositoryAsync(workspace, credentials: null, cancellationToken);
+            }
+
+            workspace.LocalDirectoryImportModeUsed = LocalDirectoryImportMode.Copy;
+        }
+        finally
+        {
+            workspace.GitUrl = originalGitUrl;
+        }
+    }
+
+    private async Task PrepareLocalGitWorkspaceWithCliAsync(
+        RepositoryWorkspace workspace,
+        string sourcePath,
+        CancellationToken cancellationToken)
+    {
+        var sourceSafeDirectories = BuildGitCliSafeDirectories(sourcePath);
+        var workspaceSafeDirectories = BuildGitCliSafeDirectories(workspace.WorkingDirectory, sourcePath);
+        var sourceUploadPackArgument = BuildGitCliUploadPackArgument(sourceSafeDirectories);
+
+        var targetBranch = await GetGitCliBranchHeadCommitAsync(
+                sourcePath,
+                workspace.BranchName,
+                cancellationToken,
+                sourceSafeDirectories)
+            ?? throw new InvalidOperationException(
+                $"Branch '{workspace.BranchName}' not found in local git source: {sourcePath}");
+
+        _logger.LogInformation(
+            "Resolved local git source branch via git CLI. SourcePath: {SourcePath}, Branch: {Branch}, SourceRef: {SourceRef}, FetchRefSpec: {FetchRefSpec}, Commit: {CommitId}",
+            sourcePath, workspace.BranchName, targetBranch.SourceRef, targetBranch.FetchRefSpec, targetBranch.CommitId);
+
+        if (await IsValidGitCliWorkspaceForSourceAsync(
+                workspace.WorkingDirectory,
+                sourcePath,
+                workspaceSafeDirectories,
+                cancellationToken))
+        {
+            await FetchGitCliBranchAsync(
+                workspace.WorkingDirectory,
+                sourceUploadPackArgument,
+                targetBranch,
+                workspaceSafeDirectories,
+                cancellationToken);
+        }
+        else
+        {
+            var reason = await GetGitCliWorkspaceInvalidReasonAsync(
+                workspace.WorkingDirectory,
+                sourcePath,
+                workspaceSafeDirectories,
+                cancellationToken);
+            _logger.LogWarning(
+                "Existing local git workspace is missing, invalid, or points at a different source; recloning. SourcePath: {SourcePath}, Branch: {Branch}, TargetPath: {Path}, Reason: {Reason}",
+                sourcePath, workspace.BranchName, workspace.WorkingDirectory, reason);
+
+            DeleteWorkspaceDirectoryWithinRepositoryRoot(workspace.WorkingDirectory, sourcePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(workspace.WorkingDirectory)!);
+            await RunGitCliAsync(
+                Directory.GetCurrentDirectory(),
+                [
+                    "clone",
+                    "--no-local",
+                    sourceUploadPackArgument,
+                    "--no-checkout",
+                    sourcePath,
+                    workspace.WorkingDirectory
+                ],
+                cancellationToken,
+                throwOnError: true,
+                safeDirectories: BuildGitCliSafeDirectories(sourcePath, workspace.WorkingDirectory));
+        }
+
+        workspaceSafeDirectories = BuildGitCliSafeDirectories(workspace.WorkingDirectory, sourcePath);
+        await FetchGitCliBranchAsync(
+            workspace.WorkingDirectory,
+            sourceUploadPackArgument,
+            targetBranch,
+            workspaceSafeDirectories,
+            cancellationToken);
+        await EnsureGitCliWorkspaceHasCommitAsync(
+            workspace.WorkingDirectory,
+            targetBranch.CommitId,
+            workspaceSafeDirectories,
+            cancellationToken,
+            targetBranch.FetchRefSpec);
+        await RunGitCliAsync(
+            workspace.WorkingDirectory,
+            ["checkout", "-B", workspace.BranchName, targetBranch.CommitId],
+            cancellationToken,
+            throwOnError: true,
+            safeDirectories: workspaceSafeDirectories);
+        await RunGitCliAsync(
+            workspace.WorkingDirectory,
+            ["reset", "--hard", targetBranch.CommitId],
+            cancellationToken,
+            throwOnError: true,
+            safeDirectories: workspaceSafeDirectories);
+
+        workspace.LocalDirectoryImportModeUsed = LocalDirectoryImportMode.Copy;
+    }
+
     private void CopyDirectory(string sourceDirectory, string destinationDirectory)
     {
         var sourceInfo = new DirectoryInfo(sourceDirectory);
@@ -425,6 +650,664 @@ public class RepositoryAnalyzer : IRepositoryAnalyzer
     {
         return !string.IsNullOrEmpty(fileSystemInfo.LinkTarget) ||
                fileSystemInfo.Attributes.HasFlag(FileAttributes.ReparsePoint);
+    }
+
+    private bool TryResolveLocalGitSource(
+        string path,
+        out LocalGitSource localGitSource,
+        out string failureReason)
+    {
+        localGitSource = default;
+
+        if (TryOpenExactGitWorkdir(path, out var repository, out failureReason))
+        {
+            repository.Dispose();
+            localGitSource = new LocalGitSource(path, LocalGitAccessMode.LibGit2);
+            _logger.LogInformation(
+                "Decoded local source path is an exact Git workdir. SourcePath: {SourcePath}, AccessMode: {AccessMode}",
+                path, localGitSource.AccessMode);
+            return true;
+        }
+
+        if (TryResolveGitCliExactWorkdir(path, out var cliTopLevel, out var cliFailureReason))
+        {
+            localGitSource = new LocalGitSource(path, LocalGitAccessMode.GitCli);
+            failureReason = $"LibGit2 exact workdir failed: {failureReason}; git CLI exact workdir succeeded: {cliTopLevel}";
+            _logger.LogWarning(
+                "Decoded local source path is an exact Git workdir via git CLI fallback. SourcePath: {SourcePath}, TopLevel: {TopLevel}, LibGit2Reason: {LibGit2Reason}",
+                path, cliTopLevel, failureReason);
+            return true;
+        }
+
+        failureReason = $"LibGit2 exact workdir failed: {failureReason}; git CLI exact workdir failed: {cliFailureReason}";
+        return false;
+    }
+
+    private static Commit? ResolveLocalSourceBranchTip(GitRepository repository, string branchName)
+    {
+        var localBranch = repository.Branches[branchName];
+        if (localBranch is { IsRemote: false })
+        {
+            return localBranch.Tip;
+        }
+
+        var originBranch = repository.Branches[$"origin/{branchName}"];
+        return originBranch?.Tip;
+    }
+
+    private static bool TryResolveLocalSourceMatchingRemoteRefTip(
+        GitRepository repository,
+        string branchName,
+        out Commit commit)
+    {
+        commit = null!;
+        var branch = repository.Branches[branchName];
+        if (branch is { IsRemote: true } &&
+            string.Equals(
+                branch.CanonicalName,
+                $"refs/remotes/{branchName}",
+                StringComparison.Ordinal))
+        {
+            commit = branch.Tip;
+            return true;
+        }
+
+        var reference = repository.Refs[$"refs/remotes/{branchName}"];
+        var directReference = reference?.ResolveToDirectReference();
+        if (directReference?.Target is not Commit targetCommit)
+        {
+            return false;
+        }
+
+        commit = targetCommit;
+        return true;
+    }
+
+    private static bool IsValidWorkspaceForSource(string workspacePath, string sourcePath, out string reason)
+    {
+        if (!TryOpenExactGitWorkdir(workspacePath, out var repository, out reason))
+        {
+            return false;
+        }
+
+        using (repository)
+        {
+            var remote = repository.Network.Remotes["origin"];
+            if (remote == null)
+            {
+                reason = "workspace has no origin remote";
+                return false;
+            }
+
+            if (!LocalPathEquals(remote.Url, sourcePath))
+            {
+                reason = $"workspace origin '{remote.Url}' does not match source '{sourcePath}'";
+                return false;
+            }
+
+            reason = "workspace is an exact Git workdir and origin matches source";
+            return true;
+        }
+    }
+
+    private static bool TryOpenExactGitWorkdir(string path, out GitRepository repository, out string reason)
+    {
+        repository = null!;
+        reason = "unknown";
+
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+        {
+            reason = $"path does not exist or is not a directory: {path}";
+            return false;
+        }
+
+        try
+        {
+            var candidate = new GitRepository(path);
+            var workingDirectory = candidate.Info.WorkingDirectory;
+            if (!LocalPathEquals(workingDirectory, path))
+            {
+                reason = $"opened Git workdir root '{workingDirectory}' does not equal requested path '{path}'";
+                candidate.Dispose();
+                return false;
+            }
+
+            repository = candidate;
+            reason = "exact Git workdir";
+            return true;
+        }
+        catch (RepositoryNotFoundException ex)
+        {
+            reason = ex.Message;
+            return false;
+        }
+        catch (LibGit2SharpException ex)
+        {
+            reason = ex.Message;
+            return false;
+        }
+    }
+
+    private bool TryResolveGitCliExactWorkdir(string path, out string topLevel, out string reason)
+    {
+        topLevel = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+        {
+            reason = $"path does not exist or is not a directory: {path}";
+            return false;
+        }
+
+        var result = RunGitCli(
+            path,
+            ["rev-parse", "--show-toplevel"],
+            BuildGitCliSafeDirectories(path));
+        if (result.ExitCode != 0)
+        {
+            reason = $"git rev-parse --show-toplevel failed with exit {result.ExitCode}: {result.Error}";
+            return false;
+        }
+
+        topLevel = result.Output.Trim();
+        if (!LocalPathEquals(topLevel, path))
+        {
+            reason = $"git CLI workdir root '{topLevel}' does not equal requested path '{path}'";
+            return false;
+        }
+
+        reason = "exact Git workdir via git CLI";
+        return true;
+    }
+
+    private async Task<GitCliBranchHead?> GetGitCliBranchHeadCommitAsync(
+        string sourcePath,
+        string branchName,
+        CancellationToken cancellationToken,
+        IReadOnlyList<string>? safeDirectories = null)
+    {
+        safeDirectories ??= BuildGitCliSafeDirectories(sourcePath);
+
+        var localResult = await RunGitCliAsync(
+            sourcePath,
+            ["rev-parse", "--verify", $"refs/heads/{branchName}^{{commit}}"],
+            cancellationToken,
+            throwOnError: false,
+            safeDirectories: safeDirectories);
+        if (localResult.ExitCode == 0)
+        {
+            return new GitCliBranchHead(
+                localResult.Output.Trim(),
+                $"refs/heads/{branchName}",
+                $"+refs/heads/{branchName}:refs/remotes/origin/{branchName}");
+        }
+
+        var remoteResult = await RunGitCliAsync(
+            sourcePath,
+            ["rev-parse", "--verify", $"refs/remotes/origin/{branchName}^{{commit}}"],
+            cancellationToken,
+            throwOnError: false,
+            safeDirectories: safeDirectories);
+        if (remoteResult.ExitCode == 0)
+        {
+            return new GitCliBranchHead(
+                remoteResult.Output.Trim(),
+                $"refs/remotes/origin/{branchName}",
+                $"+refs/remotes/origin/{branchName}:refs/remotes/origin/{branchName}");
+        }
+
+        var matchingRemoteResult = await RunGitCliAsync(
+            sourcePath,
+            ["rev-parse", "--verify", $"refs/remotes/{branchName}^{{commit}}"],
+            cancellationToken,
+            throwOnError: false,
+            safeDirectories: safeDirectories);
+        if (matchingRemoteResult.ExitCode == 0)
+        {
+            return new GitCliBranchHead(
+                matchingRemoteResult.Output.Trim(),
+                $"refs/remotes/{branchName}",
+                $"+refs/remotes/{branchName}:refs/remotes/origin/{branchName}");
+        }
+
+        _logger.LogWarning(
+            "Unable to resolve local git source branch via git CLI. SourcePath: {SourcePath}, Branch: {Branch}, LocalError: {LocalError}, OriginRemoteError: {OriginRemoteError}, MatchingRemoteError: {MatchingRemoteError}",
+            sourcePath, branchName, localResult.Error, remoteResult.Error, matchingRemoteResult.Error);
+        return null;
+    }
+
+    private async Task FetchGitCliBranchAsync(
+        string workspacePath,
+        string sourceUploadPackArgument,
+        GitCliBranchHead targetBranch,
+        IReadOnlyList<string> safeDirectories,
+        CancellationToken cancellationToken)
+    {
+        await RunGitCliAsync(
+            workspacePath,
+            ["fetch", sourceUploadPackArgument, "origin", targetBranch.FetchRefSpec],
+            cancellationToken,
+            throwOnError: true,
+            safeDirectories: safeDirectories);
+    }
+
+    private async Task EnsureGitCliWorkspaceHasCommitAsync(
+        string workspacePath,
+        string targetCommit,
+        IReadOnlyList<string> safeDirectories,
+        CancellationToken cancellationToken,
+        string fetchRefSpec)
+    {
+        var result = await RunGitCliAsync(
+            workspacePath,
+            ["cat-file", "-t", targetCommit],
+            cancellationToken,
+            throwOnError: false,
+            safeDirectories: safeDirectories);
+        if (result.ExitCode == 0 &&
+            string.Equals(result.Output.Trim(), "commit", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var showRef = await RunGitCliAsync(
+            workspacePath,
+            ["show-ref"],
+            cancellationToken,
+            throwOnError: false,
+            safeDirectories: safeDirectories);
+
+        throw new InvalidOperationException(
+            $"Fetched local git source ref but target commit is not available in workspace. " +
+            $"Workspace: {workspacePath}, Commit: {targetCommit}, FetchRefSpec: {fetchRefSpec}, " +
+            $"CatFileExitCode: {result.ExitCode}, CatFileOutput: {result.Output}, CatFileError: {result.Error}, " +
+            $"ShowRef: {showRef.Output}");
+    }
+
+    private async Task<bool> IsValidGitCliWorkspaceForSourceAsync(
+        string workspacePath,
+        string sourcePath,
+        IReadOnlyList<string> safeDirectories,
+        CancellationToken cancellationToken)
+    {
+        return string.Equals(
+            await GetGitCliWorkspaceInvalidReasonAsync(workspacePath, sourcePath, safeDirectories, cancellationToken),
+            "workspace is an exact Git workdir and origin matches source",
+            StringComparison.Ordinal);
+    }
+
+    private async Task<string> GetGitCliWorkspaceInvalidReasonAsync(
+        string workspacePath,
+        string sourcePath,
+        IReadOnlyList<string> safeDirectories,
+        CancellationToken cancellationToken)
+    {
+        if (!Directory.Exists(workspacePath))
+        {
+            return $"workspace path does not exist: {workspacePath}";
+        }
+
+        var topLevelResult = await RunGitCliAsync(
+            workspacePath,
+            ["rev-parse", "--show-toplevel"],
+            cancellationToken,
+            throwOnError: false,
+            safeDirectories: safeDirectories);
+        if (topLevelResult.ExitCode != 0)
+        {
+            return $"git rev-parse --show-toplevel failed with exit {topLevelResult.ExitCode}: {topLevelResult.Error}";
+        }
+
+        var topLevel = topLevelResult.Output.Trim();
+        if (!LocalPathEquals(topLevel, workspacePath))
+        {
+            return $"workspace Git root '{topLevel}' does not equal target path '{workspacePath}'";
+        }
+
+        var originResult = await RunGitCliAsync(
+            workspacePath,
+            ["remote", "get-url", "origin"],
+            cancellationToken,
+            throwOnError: false,
+            safeDirectories: safeDirectories);
+        if (originResult.ExitCode != 0)
+        {
+            return $"git remote get-url origin failed with exit {originResult.ExitCode}: {originResult.Error}";
+        }
+
+        var originUrl = originResult.Output.Trim();
+        if (!LocalPathEquals(originUrl, sourcePath))
+        {
+            return $"workspace origin '{originUrl}' does not match source '{sourcePath}'";
+        }
+
+        return "workspace is an exact Git workdir and origin matches source";
+    }
+
+    private GitCliResult RunGitCli(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<string>? safeDirectories = null)
+    {
+        safeDirectories ??= [];
+        LogGitCliCommand(workingDirectory, arguments, safeDirectories);
+
+        try
+        {
+            using var process = StartGitCli(workingDirectory, arguments, safeDirectories);
+            if (process == null)
+            {
+                return new GitCliResult(-1, string.Empty, "Failed to start git process");
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            return new GitCliResult(process.ExitCode, output.Trim(), error.Trim());
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or FileNotFoundException)
+        {
+            return new GitCliResult(-1, string.Empty, ex.Message);
+        }
+    }
+
+    private async Task<GitCliResult> RunGitCliAsync(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken,
+        bool throwOnError,
+        IReadOnlyList<string>? safeDirectories = null)
+    {
+        safeDirectories ??= [];
+        LogGitCliCommand(workingDirectory, arguments, safeDirectories);
+
+        using var process = StartGitCli(workingDirectory, arguments, safeDirectories);
+        if (process == null)
+        {
+            throw new InvalidOperationException("Failed to start git process");
+        }
+
+        var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+        var result = new GitCliResult(
+            process.ExitCode,
+            (await outputTask).Trim(),
+            (await errorTask).Trim());
+
+        if (throwOnError && result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"git {string.Join(' ', arguments)} failed in {workingDirectory} with exit {result.ExitCode}: {result.Error}");
+        }
+
+        return result;
+    }
+
+    private void LogGitCliCommand(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<string> safeDirectories)
+    {
+        _logger.LogInformation(
+            "Running git command. WorkingDirectory: {WorkingDirectory}, Arguments: {Arguments}, FullArguments: {FullArguments}, SafeDirectories: {SafeDirectories}",
+            workingDirectory,
+            string.Join(' ', arguments),
+            string.Join(' ', BuildGitCliProcessArguments(arguments, safeDirectories).Select(QuoteGitCliArgumentForLog)),
+            string.Join(", ", safeDirectories));
+    }
+
+    private static Process? StartGitCli(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<string> safeDirectories)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        foreach (var argument in BuildGitCliProcessArguments(arguments, safeDirectories))
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return Process.Start(startInfo);
+    }
+
+    private static IEnumerable<string> BuildGitCliProcessArguments(
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<string> safeDirectories)
+    {
+        foreach (var safeDirectory in safeDirectories.Where(path => !string.IsNullOrWhiteSpace(path)))
+        {
+            yield return "-c";
+            yield return $"safe.directory={safeDirectory}";
+        }
+
+        foreach (var argument in arguments)
+        {
+            yield return argument;
+        }
+    }
+
+    private static string BuildGitCliUploadPackArgument(IReadOnlyList<string> safeDirectories)
+    {
+        var uploadPackArguments = new List<string> { "git" };
+        foreach (var safeDirectory in safeDirectories.Where(path => !string.IsNullOrWhiteSpace(path)))
+        {
+            uploadPackArguments.Add("-c");
+            uploadPackArguments.Add($"safe.directory={safeDirectory}");
+        }
+
+        uploadPackArguments.Add("upload-pack");
+        return $"--upload-pack={string.Join(' ', uploadPackArguments.Select(QuoteGitCliArgumentForShell))}";
+    }
+
+    private static string QuoteGitCliArgumentForLog(string argument)
+    {
+        return argument.Any(char.IsWhiteSpace)
+            ? $"\"{argument.Replace("\"", "\\\"", StringComparison.Ordinal)}\""
+            : argument;
+    }
+
+    private static string QuoteGitCliArgumentForShell(string argument)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return argument.Any(char.IsWhiteSpace)
+                ? $"\"{argument.Replace("\"", "\\\"", StringComparison.Ordinal)}\""
+                : argument;
+        }
+
+        return argument.Contains('\'', StringComparison.Ordinal) || argument.Any(char.IsWhiteSpace)
+            ? $"'{argument.Replace("'", "'\"'\"'", StringComparison.Ordinal)}'"
+            : argument;
+    }
+
+    private static IReadOnlyList<string> BuildGitCliSafeDirectories(params string[] paths)
+    {
+        var safeDirectories = new List<string>();
+        var seen = new HashSet<string>(GetPathComparison() == StringComparison.OrdinalIgnoreCase
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal);
+
+        foreach (var path in paths)
+        {
+            AddSafeDirectory(safeDirectories, seen, path);
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                continue;
+            }
+
+            var normalizedPath = NormalizeLocalPath(path);
+            var gitPath = Path.Combine(normalizedPath, ".git");
+            if (File.Exists(gitPath) || Directory.Exists(gitPath))
+            {
+                AddSafeDirectory(safeDirectories, seen, gitPath);
+            }
+
+            if (TryResolveGitDirPointer(gitPath, normalizedPath, out var gitDir))
+            {
+                AddSafeDirectory(safeDirectories, seen, gitDir);
+
+                if (TryResolveGitCommonDir(gitDir, out var commonGitDir))
+                {
+                    AddSafeDirectory(safeDirectories, seen, commonGitDir);
+                }
+            }
+        }
+
+        return safeDirectories;
+    }
+
+    private static void AddSafeDirectory(
+        List<string> safeDirectories,
+        HashSet<string> seen,
+        string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        var normalizedPath = NormalizeLocalPath(path);
+        if (seen.Add(normalizedPath))
+        {
+            safeDirectories.Add(normalizedPath);
+        }
+    }
+
+    private static bool TryResolveGitDirPointer(
+        string gitPath,
+        string worktreePath,
+        out string gitDir)
+    {
+        gitDir = string.Empty;
+
+        if (!File.Exists(gitPath))
+        {
+            return false;
+        }
+
+        var firstLine = File.ReadLines(gitPath).FirstOrDefault();
+        if (firstLine == null ||
+            !firstLine.StartsWith("gitdir:", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var value = firstLine["gitdir:".Length..].Trim();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        gitDir = Path.IsPathRooted(value)
+            ? NormalizeLocalPath(value)
+            : NormalizeLocalPath(Path.Combine(worktreePath, value));
+        return true;
+    }
+
+    private static bool TryResolveGitCommonDir(string gitDir, out string commonGitDir)
+    {
+        commonGitDir = string.Empty;
+        var commonDirPath = Path.Combine(gitDir, "commondir");
+        if (!File.Exists(commonDirPath))
+        {
+            return false;
+        }
+
+        var value = File.ReadLines(commonDirPath).FirstOrDefault()?.Trim();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        commonGitDir = Path.IsPathRooted(value)
+            ? NormalizeLocalPath(value)
+            : NormalizeLocalPath(Path.Combine(gitDir, value));
+        return true;
+    }
+
+    private void DeleteWorkspaceDirectoryWithinRepositoryRoot(string workspacePath, string sourcePath)
+    {
+        if (!Directory.Exists(workspacePath))
+        {
+            return;
+        }
+
+        var normalizedWorkspace = NormalizeLocalPath(workspacePath);
+        var normalizedSource = NormalizeLocalPath(sourcePath);
+        if (PathsEqual(normalizedWorkspace, normalizedSource))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to delete local git source while preparing workspace: {workspacePath}");
+        }
+
+        var normalizedRoot = NormalizeLocalPath(_options.RepositoriesDirectory);
+        if (PathsEqual(normalizedWorkspace, normalizedRoot) ||
+            !IsPathUnder(normalizedWorkspace, normalizedRoot))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to delete workspace outside repository root. Workspace: {workspacePath}, Root: {_options.RepositoriesDirectory}");
+        }
+
+        DeleteDirectoryRecursive(workspacePath);
+    }
+
+    private static bool LocalPathEquals(string pathA, string pathB)
+    {
+        return PathsEqual(NormalizeLocalPath(pathA), NormalizeLocalPath(pathB));
+    }
+
+    private static bool PathsEqual(string normalizedPathA, string normalizedPathB)
+    {
+        return string.Equals(normalizedPathA, normalizedPathB, GetPathComparison());
+    }
+
+    private static bool IsPathUnder(string normalizedPath, string normalizedParent)
+    {
+        var parentWithSeparator = normalizedParent.EndsWith(Path.DirectorySeparatorChar)
+            ? normalizedParent
+            : normalizedParent + Path.DirectorySeparatorChar;
+
+        return normalizedPath.StartsWith(parentWithSeparator, GetPathComparison());
+    }
+
+    private static string NormalizeLocalPath(string path)
+    {
+        if (Uri.TryCreate(path, UriKind.Absolute, out var uri) && uri.IsFile)
+        {
+            path = uri.LocalPath;
+        }
+
+        return Path.GetFullPath(path)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    private static StringComparison GetPathComparison()
+    {
+        return OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+    }
+
+    private readonly record struct LocalGitSource(string RepositoryPath, LocalGitAccessMode AccessMode);
+
+    private readonly record struct GitCliBranchHead(string CommitId, string SourceRef, string FetchRefSpec);
+
+    private readonly record struct GitCliResult(int ExitCode, string Output, string Error);
+
+    private enum LocalGitAccessMode
+    {
+        LibGit2,
+        GitCli
     }
 
     private static string ComputeDirectorySnapshotId(string directoryPath)

--- a/tests/OpenDeepWiki.Tests/Services/Repositories/IncrementalUpdateWorkerTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/Repositories/IncrementalUpdateWorkerTests.cs
@@ -13,6 +13,12 @@ namespace OpenDeepWiki.Tests.Services.Repositories;
 
 public class IncrementalUpdateWorkerTests
 {
+    private const string SnapshotHash =
+        "8FDD97DF787CB40485E5D1BDA171AC1608EDEE9649D107E3E6B6C1D4A0E28C0A";
+
+    private const string GitCommitA = "4d24129e28470a23b7d755ba1eeb58fce09447ac";
+    private const string GitCommitB = "71d424d03595ecc2350215bbf03f6e6944e71a83";
+
     [Fact]
     public async Task CheckScheduledUpdatesAsync_WhenRemoteHeadMatchesLastCommit_DoesNotCreateTask()
     {
@@ -57,6 +63,122 @@ public class IncrementalUpdateWorkerTests
         Assert.Equal(IncrementalUpdateStatus.Pending, task.Status);
         Assert.Equal("old-sha", task.PreviousCommitId);
         Assert.Equal("new-sha", task.TargetCommitId);
+        Assert.False(task.IsManualTrigger);
+        analyzer.VerifyAll();
+    }
+
+    [Fact]
+    public async Task CheckScheduledUpdatesAsync_WhenLocalGitSourceHasSnapshotBaseline_NormalizesWithoutTask()
+    {
+        using var context = CreateContext();
+        var repository = SeedRepository(
+            context,
+            updateIntervalMinutes: 60,
+            lastUpdateCheckAt: DateTime.UtcNow.AddHours(-2),
+            gitUrl: RepositorySource.EncodeLocalDirectoryPath("/tmp/source-repo"));
+        var branch = SeedBranch(context, repository.Id, "release/stable", SnapshotHash);
+        var originalLastProcessedAt = branch.LastProcessedAt;
+        await context.SaveChangesAsync();
+
+        var analyzer = new Mock<IRepositoryAnalyzer>(MockBehavior.Strict);
+        analyzer
+            .Setup(x => x.GetRemoteBranchHeadCommitAsync(repository, branch.BranchName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GitCommitA);
+
+        var worker = CreateWorker();
+
+        await InvokeCheckScheduledUpdatesAsync(worker, context, Mock.Of<IGitPlatformService>(), analyzer.Object);
+
+        Assert.Empty(await context.IncrementalUpdateTasks.ToListAsync());
+        var updatedBranch = await context.RepositoryBranches.SingleAsync(b => b.Id == branch.Id);
+        Assert.Equal(GitCommitA, updatedBranch.LastCommitId);
+        Assert.Equal(originalLastProcessedAt, updatedBranch.LastProcessedAt);
+        analyzer.VerifyAll();
+    }
+
+    [Fact]
+    public async Task CheckScheduledUpdatesAsync_WhenLocalGitSourceCommitChanges_CreatesPendingTask()
+    {
+        using var context = CreateContext();
+        var repository = SeedRepository(
+            context,
+            updateIntervalMinutes: 60,
+            lastUpdateCheckAt: DateTime.UtcNow.AddHours(-2),
+            gitUrl: RepositorySource.EncodeLocalDirectoryPath("/tmp/source-repo"));
+        var branch = SeedBranch(context, repository.Id, "release/stable", GitCommitA);
+        await context.SaveChangesAsync();
+
+        var analyzer = new Mock<IRepositoryAnalyzer>(MockBehavior.Strict);
+        analyzer
+            .Setup(x => x.GetRemoteBranchHeadCommitAsync(repository, branch.BranchName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GitCommitB);
+
+        var worker = CreateWorker();
+
+        await InvokeCheckScheduledUpdatesAsync(worker, context, Mock.Of<IGitPlatformService>(), analyzer.Object);
+
+        var task = await context.IncrementalUpdateTasks.SingleAsync();
+        Assert.Equal(IncrementalUpdateStatus.Pending, task.Status);
+        Assert.Equal(GitCommitA, task.PreviousCommitId);
+        Assert.Equal(GitCommitB, task.TargetCommitId);
+        Assert.False(task.IsManualTrigger);
+        analyzer.VerifyAll();
+    }
+
+    [Fact]
+    public async Task CheckScheduledUpdatesAsync_WhenGitRepositoryHasLegacyBaseline_CreatesPendingTask()
+    {
+        using var context = CreateContext();
+        var repository = SeedRepository(
+            context,
+            updateIntervalMinutes: 60,
+            lastUpdateCheckAt: DateTime.UtcNow.AddHours(-2));
+        var branch = SeedBranch(context, repository.Id, "main", SnapshotHash);
+        await context.SaveChangesAsync();
+
+        var analyzer = new Mock<IRepositoryAnalyzer>(MockBehavior.Strict);
+        analyzer
+            .Setup(x => x.GetRemoteBranchHeadCommitAsync(repository, branch.BranchName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GitCommitA);
+
+        var worker = CreateWorker();
+
+        await InvokeCheckScheduledUpdatesAsync(worker, context, Mock.Of<IGitPlatformService>(), analyzer.Object);
+
+        var task = await context.IncrementalUpdateTasks.SingleAsync();
+        Assert.Equal(IncrementalUpdateStatus.Pending, task.Status);
+        Assert.Equal(SnapshotHash, task.PreviousCommitId);
+        Assert.Equal(GitCommitA, task.TargetCommitId);
+        Assert.False(task.IsManualTrigger);
+        var updatedBranch = await context.RepositoryBranches.SingleAsync(b => b.Id == branch.Id);
+        Assert.Equal(SnapshotHash, updatedBranch.LastCommitId);
+        analyzer.VerifyAll();
+    }
+
+    [Fact]
+    public async Task CheckScheduledUpdatesAsync_WhenLocalDirectoryHasNoGitHead_CreatesSnapshotTask()
+    {
+        using var context = CreateContext();
+        var repository = SeedRepository(
+            context,
+            updateIntervalMinutes: 60,
+            lastUpdateCheckAt: DateTime.UtcNow.AddHours(-2),
+            gitUrl: RepositorySource.EncodeLocalDirectoryPath("/tmp/plain-directory"));
+        var branch = SeedBranch(context, repository.Id, "main", SnapshotHash);
+        await context.SaveChangesAsync();
+
+        var analyzer = new Mock<IRepositoryAnalyzer>(MockBehavior.Strict);
+        analyzer
+            .Setup(x => x.GetRemoteBranchHeadCommitAsync(repository, branch.BranchName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var worker = CreateWorker();
+
+        await InvokeCheckScheduledUpdatesAsync(worker, context, Mock.Of<IGitPlatformService>(), analyzer.Object);
+
+        var task = await context.IncrementalUpdateTasks.SingleAsync();
+        Assert.Equal(SnapshotHash, task.PreviousCommitId);
+        Assert.Null(task.TargetCommitId);
         Assert.False(task.IsManualTrigger);
         analyzer.VerifyAll();
     }
@@ -213,13 +335,14 @@ public class IncrementalUpdateWorkerTests
         TestDbContext context,
         int? updateIntervalMinutes,
         DateTime? lastUpdateCheckAt,
-        bool isDeleted = false)
+        bool isDeleted = false,
+        string? gitUrl = null)
     {
         var repository = new Repository
         {
             Id = Guid.NewGuid().ToString(),
             OwnerUserId = "user-1",
-            GitUrl = "https://example.com/demo/repo.git",
+            GitUrl = gitUrl ?? "https://example.com/demo/repo.git",
             OrgName = "demo",
             RepoName = "repo",
             Status = RepositoryStatus.Completed,

--- a/tests/OpenDeepWiki.Tests/Services/Repositories/RepositoryAnalyzerSourceTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/Repositories/RepositoryAnalyzerSourceTests.cs
@@ -1,9 +1,11 @@
 using System.IO.Compression;
+using System.Reflection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using OpenDeepWiki.Entities;
 using OpenDeepWiki.Services.Repositories;
 using Xunit;
+using GitCloneOptions = LibGit2Sharp.CloneOptions;
 using GitCommitOptions = LibGit2Sharp.CommitOptions;
 using GitCommands = LibGit2Sharp.Commands;
 using GitRepository = LibGit2Sharp.Repository;
@@ -169,6 +171,375 @@ public class RepositoryAnalyzerSourceTests
         Assert.NotEqual(aWorkspace.WorkingDirectory, bWorkspace.WorkingDirectory);
     }
 
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenLocalDirectorySourceIsGitRepository_UsesTargetBranchHead()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var sourceRoot = CreateTempDirectory();
+        var (aCommit, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "release/stable",
+            "feature/docs-refresh");
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [Path.GetDirectoryName(sourceRoot)!]
+            });
+        var repository = new Repository
+        {
+            Id = Guid.NewGuid().ToString(),
+            OwnerUserId = Guid.NewGuid().ToString(),
+            OrgName = "example-org",
+            RepoName = "sample-repo",
+            GitUrl = RepositorySource.EncodeLocalDirectoryPath(sourceRoot)
+        };
+
+        var aWorkspace = await analyzer.PrepareWorkspaceAsync(repository, "release/stable");
+        var bWorkspace = await analyzer.PrepareWorkspaceAsync(repository, "feature/docs-refresh");
+        var bRemoteHead = await analyzer.GetRemoteBranchHeadCommitAsync(repository, "feature/docs-refresh");
+
+        Assert.Equal(RepositorySourceType.LocalDirectory, bWorkspace.SourceType);
+        Assert.True(bWorkspace.SupportsIncrementalUpdates);
+        Assert.Equal(aCommit, aWorkspace.CommitId);
+        Assert.Equal("A branch", File.ReadAllText(Path.Combine(aWorkspace.WorkingDirectory, "branch.txt")));
+        Assert.Equal(bCommit, bWorkspace.CommitId);
+        Assert.Equal(bCommit, bRemoteHead);
+        Assert.Equal("B branch", File.ReadAllText(Path.Combine(bWorkspace.WorkingDirectory, "branch.txt")));
+        Assert.NotEqual(aWorkspace.WorkingDirectory, bWorkspace.WorkingDirectory);
+    }
+
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenLibGit2SourceHasOnlyMatchingRemoteRef_UsesTargetBranchHead()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var sourceRoot = CreateTempDirectory();
+        var (aCommit, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "release/stable",
+            "feature/docs-refresh");
+        using (var sourceRepository = new GitRepository(sourceRoot))
+        {
+            sourceRepository.Refs.Add(
+                "refs/remotes/feature/docs-refresh",
+                bCommit,
+                true);
+            GitCommands.Checkout(sourceRepository, (LibGit2Sharp.Commit)sourceRepository.Lookup(aCommit));
+            sourceRepository.Branches.Remove("feature/docs-refresh");
+        }
+
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [Path.GetDirectoryName(sourceRoot)!]
+            });
+        var repository = CreateLocalSourceRepository(sourceRoot);
+
+        var workspace = await analyzer.PrepareWorkspaceAsync(repository, "feature/docs-refresh");
+        var remoteHead = await analyzer.GetRemoteBranchHeadCommitAsync(repository, "feature/docs-refresh");
+
+        Assert.Equal(bCommit, workspace.CommitId);
+        Assert.Equal(bCommit, remoteHead);
+        Assert.Equal("B branch", File.ReadAllText(Path.Combine(workspace.WorkingDirectory, "branch.txt")));
+        using var workspaceRepository = new GitRepository(workspace.WorkingDirectory);
+        Assert.NotNull(workspaceRepository.Branches["origin/feature/docs-refresh"]);
+        Assert.Equal(bCommit, workspaceRepository.Branches["origin/feature/docs-refresh"].Tip.Sha);
+    }
+
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenWorkspaceIsPlainDirectoryInsideParentGitRepo_ReclonesTargetBranch()
+    {
+        var parentRoot = CreateTempDirectory();
+        GitRepository.Init(parentRoot);
+        var repositoriesRoot = Path.Combine(parentRoot, "data");
+        var sourceRoot = CreateTempDirectory();
+        var (_, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "release/stable",
+            "feature/docs-refresh");
+        var pollutedWorkspace = GetExpectedWorkspacePath(
+            repositoriesRoot,
+            "example-org",
+            "sample-repo",
+            "feature/docs-refresh");
+        Directory.CreateDirectory(pollutedWorkspace);
+        File.WriteAllText(Path.Combine(pollutedWorkspace, "branch.txt"), "polluted parent repository content");
+
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [Path.GetDirectoryName(sourceRoot)!]
+            });
+        var repository = CreateLocalSourceRepository(sourceRoot);
+
+        var workspace = await analyzer.PrepareWorkspaceAsync(repository, "feature/docs-refresh");
+
+        Assert.Equal(bCommit, workspace.CommitId);
+        Assert.Equal("B branch", File.ReadAllText(Path.Combine(workspace.WorkingDirectory, "branch.txt")));
+        using var workspaceRepository = new GitRepository(workspace.WorkingDirectory);
+        Assert.Equal(NormalizePath(workspace.WorkingDirectory), NormalizePath(workspaceRepository.Info.WorkingDirectory));
+    }
+
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenWorkspaceHasInvalidGitDirectory_Reclones()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var sourceRoot = CreateTempDirectory();
+        var (_, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "release/stable",
+            "feature/docs-refresh");
+        var invalidWorkspace = GetExpectedWorkspacePath(
+            repositoriesRoot,
+            "example-org",
+            "sample-repo",
+            "feature/docs-refresh");
+        Directory.CreateDirectory(Path.Combine(invalidWorkspace, ".git"));
+
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [Path.GetDirectoryName(sourceRoot)!]
+            });
+        var repository = CreateLocalSourceRepository(sourceRoot);
+
+        var workspace = await analyzer.PrepareWorkspaceAsync(repository, "feature/docs-refresh");
+
+        Assert.Equal(bCommit, workspace.CommitId);
+        Assert.Equal("B branch", File.ReadAllText(Path.Combine(workspace.WorkingDirectory, "branch.txt")));
+    }
+
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenWorkspaceOriginPointsAtDifferentSource_Reclones()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var rightSourceRoot = CreateTempDirectory();
+        var wrongSourceRoot = CreateTempDirectory();
+        var (_, rightBCommit) = CreateGitRepositoryWithBranches(
+            rightSourceRoot,
+            "release/stable",
+            "feature/docs-refresh",
+            bContent: "right B branch");
+        CreateGitRepositoryWithBranches(
+            wrongSourceRoot,
+            "release/stable",
+            "feature/docs-refresh",
+            bContent: "wrong B branch");
+        var workspacePath = GetExpectedWorkspacePath(
+            repositoriesRoot,
+            "example-org",
+            "sample-repo",
+            "feature/docs-refresh");
+        GitRepository.Clone(
+            wrongSourceRoot,
+            workspacePath,
+            new GitCloneOptions { BranchName = "feature/docs-refresh" });
+
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [Path.GetDirectoryName(rightSourceRoot)!]
+            });
+        var repository = CreateLocalSourceRepository(rightSourceRoot);
+
+        var workspace = await analyzer.PrepareWorkspaceAsync(repository, "feature/docs-refresh");
+
+        Assert.Equal(rightBCommit, workspace.CommitId);
+        Assert.Equal("right B branch", File.ReadAllText(Path.Combine(workspace.WorkingDirectory, "branch.txt")));
+        using var workspaceRepository = new GitRepository(workspace.WorkingDirectory);
+        Assert.Equal(NormalizePath(rightSourceRoot), NormalizePath(workspaceRepository.Network.Remotes["origin"].Url));
+    }
+
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenLocalDirectorySourceIsGitRepoSubdirectory_DoesNotUseParentGitRepository()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var parentRoot = CreateTempDirectory();
+        GitRepository.Init(parentRoot);
+        using (var parentRepository = new GitRepository(parentRoot))
+        {
+            var signature = new GitSignature("OpenDeepWiki Tests", "tests@opendeepwiki.local", DateTimeOffset.UtcNow);
+            Directory.CreateDirectory(Path.Combine(parentRoot, "nested-source"));
+            File.WriteAllText(Path.Combine(parentRoot, "nested-source", "branch.txt"), "plain nested source");
+            GitCommands.Stage(parentRepository, "nested-source/branch.txt");
+            parentRepository.Commit("Parent commit", signature, signature, new GitCommitOptions());
+        }
+
+        var sourceSubdirectory = Path.Combine(parentRoot, "nested-source");
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [parentRoot]
+            });
+        var repository = CreateLocalSourceRepository(sourceSubdirectory);
+
+        var workspace = await analyzer.PrepareWorkspaceAsync(repository, "feature/docs-refresh");
+
+        Assert.False(workspace.SupportsIncrementalUpdates);
+        Assert.Equal(64, workspace.CommitId.Length);
+        Assert.Equal("plain nested source", File.ReadAllText(Path.Combine(workspace.WorkingDirectory, "branch.txt")));
+        Assert.False(Directory.Exists(Path.Combine(workspace.WorkingDirectory, ".git")));
+    }
+
+    [Fact]
+    public async Task PrepareWorkspaceAsync_WhenLocalDirectorySourceIsGitWorktree_UsesTargetBranchHead()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var sourceRoot = CreateTempDirectory();
+        var worktreeRoot = CreateTempDirectory();
+        Directory.Delete(worktreeRoot);
+        var (_, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "release/stable",
+            "feature/docs-refresh");
+        using (var sourceRepository = new GitRepository(sourceRoot))
+        {
+            sourceRepository.Worktrees.Add(
+                "release/stable",
+                "source-worktree",
+                worktreeRoot,
+                isLocked: false);
+        }
+
+        var analyzer = CreateAnalyzer(
+            repositoriesRoot,
+            new RepositoryAnalyzerOptions
+            {
+                RepositoriesDirectory = repositoriesRoot,
+                AllowedLocalPathRoots = [Path.GetDirectoryName(worktreeRoot)!]
+            });
+        var repository = CreateLocalSourceRepository(worktreeRoot);
+
+        var workspace = await analyzer.PrepareWorkspaceAsync(repository, "feature/docs-refresh");
+
+        Assert.True(File.Exists(Path.Combine(worktreeRoot, ".git")));
+        Assert.Equal(bCommit, workspace.CommitId);
+        Assert.Equal("B branch", File.ReadAllText(Path.Combine(workspace.WorkingDirectory, "branch.txt")));
+    }
+
+    [Fact]
+    public void BuildGitCliSafeDirectories_WhenSourceIsGitWorktree_IncludesWorktreeGitFileAndCommonGitDir()
+    {
+        var sourceRoot = CreateTempDirectory();
+        var worktreeRoot = CreateTempDirectory();
+        Directory.Delete(worktreeRoot);
+        CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "release/stable",
+            "feature/docs-refresh");
+        using (var sourceRepository = new GitRepository(sourceRoot))
+        {
+            sourceRepository.Worktrees.Add(
+                "release/stable",
+                "source-worktree",
+                worktreeRoot,
+                isLocked: false);
+        }
+
+        var gitFile = Path.Combine(worktreeRoot, ".git");
+        var gitDir = ResolveGitDirPointerForTest(gitFile, worktreeRoot);
+        var commonGitDir = ResolveCommonGitDirForTest(gitDir);
+        var safeDirectories = InvokeBuildGitCliSafeDirectories(worktreeRoot)
+            .Select(NormalizePath)
+            .ToArray();
+
+        Assert.Contains(NormalizePath(worktreeRoot), safeDirectories);
+        Assert.Contains(NormalizePath(gitFile), safeDirectories);
+        Assert.Contains(NormalizePath(gitDir), safeDirectories);
+        Assert.Contains(NormalizePath(commonGitDir), safeDirectories);
+    }
+
+    [Fact]
+    public void BuildGitCliUploadPackArgument_IncludesSafeDirectoriesBeforeUploadPack()
+    {
+        var sourceRoot = NormalizePath(Path.Combine(CreateTempDirectory(), "source with space"));
+        var gitDir = NormalizePath(Path.Combine(sourceRoot, ".git"));
+        var argument = InvokeBuildGitCliUploadPackArgument([sourceRoot, gitDir]);
+        var processArguments = InvokeBuildGitCliProcessArguments(
+            ["clone", "--no-local", argument, "--no-checkout", sourceRoot, "/tmp/target"],
+            [sourceRoot, gitDir]);
+
+        Assert.Contains($"-c 'safe.directory={sourceRoot}'", argument);
+        Assert.Contains($"-c 'safe.directory={gitDir}'", argument);
+        Assert.EndsWith(" upload-pack", argument);
+        Assert.Equal("-c", processArguments[0]);
+        Assert.Equal($"safe.directory={sourceRoot}", processArguments[1]);
+        Assert.Equal("-c", processArguments[2]);
+        Assert.Equal($"safe.directory={gitDir}", processArguments[3]);
+        Assert.Equal("clone", processArguments[4]);
+        Assert.Equal("--no-local", processArguments[5]);
+        Assert.Equal(argument, processArguments[6]);
+    }
+
+    [Fact]
+    public async Task GetGitCliBranchHeadCommitAsync_WhenLocalBranchExists_ReturnsExplicitFetchRefSpec()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var sourceRoot = CreateTempDirectory();
+        var (_, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "release/stable",
+            "feature/docs-refresh");
+        var analyzer = CreateAnalyzer(repositoriesRoot);
+
+        var result = await InvokeGetGitCliBranchHeadCommitAsync(
+            analyzer,
+            sourceRoot,
+            "feature/docs-refresh");
+
+        Assert.NotNull(result);
+        Assert.Equal(bCommit, GetReflectedStringProperty(result, "CommitId"));
+        Assert.Equal("refs/heads/feature/docs-refresh", GetReflectedStringProperty(result, "SourceRef"));
+        Assert.Equal(
+            "+refs/heads/feature/docs-refresh:refs/remotes/origin/feature/docs-refresh",
+            GetReflectedStringProperty(result, "FetchRefSpec"));
+    }
+
+    [Fact]
+    public async Task GetGitCliBranchHeadCommitAsync_WhenMatchingRemoteRefExists_ReturnsRemoteFetchRefSpec()
+    {
+        var repositoriesRoot = CreateTempDirectory();
+        var sourceRoot = CreateTempDirectory();
+        var (aCommit, bCommit) = CreateGitRepositoryWithBranches(
+            sourceRoot,
+            "release/stable",
+            "feature/docs-refresh");
+        using (var sourceRepository = new GitRepository(sourceRoot))
+        {
+            sourceRepository.Refs.Add(
+                "refs/remotes/feature/docs-refresh",
+                bCommit,
+                true);
+            GitCommands.Checkout(sourceRepository, (LibGit2Sharp.Commit)sourceRepository.Lookup(aCommit));
+            sourceRepository.Branches.Remove("feature/docs-refresh");
+        }
+
+        var analyzer = CreateAnalyzer(repositoriesRoot);
+
+        var result = await InvokeGetGitCliBranchHeadCommitAsync(
+            analyzer,
+            sourceRoot,
+            "feature/docs-refresh");
+
+        Assert.NotNull(result);
+        Assert.Equal(bCommit, GetReflectedStringProperty(result, "CommitId"));
+        Assert.Equal("refs/remotes/feature/docs-refresh", GetReflectedStringProperty(result, "SourceRef"));
+        Assert.Equal(
+            "+refs/remotes/feature/docs-refresh:refs/remotes/origin/feature/docs-refresh",
+            GetReflectedStringProperty(result, "FetchRefSpec"));
+    }
+
     private static RepositoryAnalyzer CreateAnalyzer(string repositoriesRoot, RepositoryAnalyzerOptions? options = null)
     {
         return new RepositoryAnalyzer(
@@ -178,6 +549,76 @@ public class RepositoryAnalyzerSourceTests
                 AllowedLocalPathRoots = []
             }),
             NullLogger<RepositoryAnalyzer>.Instance);
+    }
+
+    private static IReadOnlyList<string> InvokeBuildGitCliSafeDirectories(params string[] paths)
+    {
+        var method = typeof(RepositoryAnalyzer).GetMethod(
+            "BuildGitCliSafeDirectories",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return Assert.IsAssignableFrom<IReadOnlyList<string>>(method.Invoke(null, [paths]));
+    }
+
+    private static string InvokeBuildGitCliUploadPackArgument(IReadOnlyList<string> safeDirectories)
+    {
+        var method = typeof(RepositoryAnalyzer).GetMethod(
+            "BuildGitCliUploadPackArgument",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return Assert.IsType<string>(method.Invoke(null, [safeDirectories]));
+    }
+
+    private static string[] InvokeBuildGitCliProcessArguments(
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<string> safeDirectories)
+    {
+        var method = typeof(RepositoryAnalyzer).GetMethod(
+            "BuildGitCliProcessArguments",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        var result = Assert.IsAssignableFrom<IEnumerable<string>>(
+            method.Invoke(null, [arguments, safeDirectories]));
+        return result.ToArray();
+    }
+
+    private static async Task<object?> InvokeGetGitCliBranchHeadCommitAsync(
+        RepositoryAnalyzer analyzer,
+        string sourcePath,
+        string branchName)
+    {
+        var method = typeof(RepositoryAnalyzer).GetMethod(
+            "GetGitCliBranchHeadCommitAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        var task = Assert.IsAssignableFrom<Task>(method.Invoke(
+            analyzer,
+            [sourcePath, branchName, CancellationToken.None, null]));
+        await task;
+        return task.GetType().GetProperty("Result")?.GetValue(task);
+    }
+
+    private static string GetReflectedStringProperty(object value, string propertyName)
+    {
+        return Assert.IsType<string>(value.GetType().GetProperty(propertyName)?.GetValue(value));
+    }
+
+    private static string ResolveGitDirPointerForTest(string gitFile, string worktreePath)
+    {
+        var firstLine = File.ReadLines(gitFile).First();
+        Assert.StartsWith("gitdir:", firstLine, StringComparison.OrdinalIgnoreCase);
+        var gitDir = firstLine["gitdir:".Length..].Trim();
+        return Path.IsPathRooted(gitDir)
+            ? NormalizePath(gitDir)
+            : NormalizePath(Path.Combine(worktreePath, gitDir));
+    }
+
+    private static string ResolveCommonGitDirForTest(string gitDir)
+    {
+        var commonDir = File.ReadLines(Path.Combine(gitDir, "commondir")).First().Trim();
+        return Path.IsPathRooted(commonDir)
+            ? NormalizePath(commonDir)
+            : NormalizePath(Path.Combine(gitDir, commonDir));
     }
 
     private static string CreateTempDirectory()
@@ -202,16 +643,65 @@ public class RepositoryAnalyzerSourceTests
         }
     }
 
+    private static Repository CreateLocalSourceRepository(string sourceRoot)
+    {
+        return new Repository
+        {
+            Id = Guid.NewGuid().ToString(),
+            OwnerUserId = Guid.NewGuid().ToString(),
+            OrgName = "example-org",
+            RepoName = "sample-repo",
+            GitUrl = RepositorySource.EncodeLocalDirectoryPath(sourceRoot)
+        };
+    }
+
+    private static string GetExpectedWorkspacePath(
+        string repositoriesRoot,
+        string orgName,
+        string repositoryName,
+        string branchName)
+    {
+        return Path.Combine(
+            repositoriesRoot,
+            SanitizePathComponent(orgName),
+            SanitizePathComponent(repositoryName),
+            "branches",
+            SanitizePathComponent(branchName),
+            "tree");
+    }
+
+    private static string SanitizePathComponent(string component)
+    {
+        return component
+            .Replace('/', '_')
+            .Replace('\\', '_')
+            .Replace("..", "_")
+            .Trim();
+    }
+
+    private static string NormalizePath(string path)
+    {
+        if (Uri.TryCreate(path, UriKind.Absolute, out var uri) && uri.IsFile)
+        {
+            path = uri.LocalPath;
+        }
+
+        return Path.GetFullPath(path)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
     private static (string ACommit, string BCommit) CreateGitRepositoryWithBranches(
         string repositoryPath,
         string branchA,
-        string branchB)
+        string branchB,
+        string aContent = "A branch",
+        string bContent = "B branch")
     {
         GitRepository.Init(repositoryPath);
         using var repository = new GitRepository(repositoryPath);
         var signature = new GitSignature("OpenDeepWiki Tests", "tests@opendeepwiki.local", DateTimeOffset.UtcNow);
 
-        File.WriteAllText(Path.Combine(repositoryPath, "branch.txt"), "A branch");
+        File.WriteAllText(Path.Combine(repositoryPath, "branch.txt"), aContent);
         GitCommands.Stage(repository, "branch.txt");
         var commitOptions = new GitCommitOptions();
         var aCommit = repository.Commit("A branch", signature, signature, commitOptions);
@@ -219,7 +709,7 @@ public class RepositoryAnalyzerSourceTests
 
         var bBranch = repository.Branches.Add(branchB, aCommit);
         GitCommands.Checkout(repository, bBranch);
-        File.WriteAllText(Path.Combine(repositoryPath, "branch.txt"), "B branch");
+        File.WriteAllText(Path.Combine(repositoryPath, "branch.txt"), bContent);
         GitCommands.Stage(repository, "branch.txt");
         var bCommit = repository.Commit("B branch", signature, signature, commitOptions);
 


### PR DESCRIPTION
## Summary

- Treat `local::...` sources that are exact Git repositories or worktrees as branch-aware Git sources.
- Reclone invalid or polluted local Git workspaces when the workspace root or origin does not match the expected target.
- Pass per-process `safe.directory` configuration through local clone/fetch upload-pack calls.
- Fetch the resolved source branch ref explicitly before checkout and validate the target commit exists in the workspace.
- Normalize legacy local-directory snapshot baselines only for exact local Git sources, while preserving normal incremental tasks for real Git commit changes.

## Validation

- `dotnet test tests/OpenDeepWiki.Tests/OpenDeepWiki.Tests.csproj --filter "FullyQualifiedName~RepositoryAnalyzerSourceTests|FullyQualifiedName~IncrementalUpdateWorkerTests"`
- `dotnet build OpenDeepWiki.sln --no-restore`
- `git diff --check origin/main..HEAD`

Follow-up correctness fix for merged PR #375.
