### PR TITLE
fix: load nested .env keys and repair stale wiki model bindings

### DIFF
--- a/src/OpenDeepWiki/Program.cs
+++ b/src/OpenDeepWiki/Program.cs
@@ -472,7 +472,7 @@ static void LoadEnvFile(IConfigurationBuilder configuration)
                 value = value[1..^1];
             }
             
-            envVars[key] = value;
+            envVars[NormalizeEnvKey(key)] = value;
             
             // 同时设置到环境变量，以便其他地方使用
             Environment.SetEnvironmentVariable(key, value);
@@ -485,4 +485,19 @@ static void LoadEnvFile(IConfigurationBuilder configuration)
     }
     
     Log.Information("No .env file found, using system environment variables only");
+}
+
+/// <summary>
+/// 将 .env 文件中的变量名转换为 .NET 配置键：
+/// - "__" 转换为 ":"（与标准环境变量命名一致，使嵌套/数组配置可被绑定）
+/// - LOCAL_IMPORT_ROOT 映射为 RepositoryAnalyzer:AllowedLocalPathRoots:0
+/// </summary>
+static string NormalizeEnvKey(string key)
+{
+    if (key.Equals("LOCAL_IMPORT_ROOT", StringComparison.OrdinalIgnoreCase))
+    {
+        return "RepositoryAnalyzer:AllowedLocalPathRoots:0";
+    }
+
+    return key.Replace("__", ":");
 }

--- a/src/OpenDeepWiki/Services/AI/AiConfigurationMigrationService.cs
+++ b/src/OpenDeepWiki/Services/AI/AiConfigurationMigrationService.cs
@@ -120,12 +120,13 @@ public class AiConfigurationMigrationService : IAiConfigurationMigrationService
     {
         var effective = legacy.WithFallback();
         modelId = string.IsNullOrWhiteSpace(modelId) ? effective.ModelId : modelId;
-        if (string.IsNullOrWhiteSpace(modelId))
-        {
-            modelId = "gpt-4o-mini";
-        }
 
         var provider = await GetOrCreateProviderAsync(displayName, effective, cancellationToken);
+        if (string.IsNullOrWhiteSpace(modelId))
+        {
+            modelId = provider.DefaultModelId ?? "gpt-4o-mini";
+        }
+
         var model = await GetOrCreateModelAsync(provider, modelId, displayName, cancellationToken);
 
         provider.DefaultModelId ??= model.ModelId;
@@ -371,6 +372,13 @@ public class AiConfigurationMigrationService : IAiConfigurationMigrationService
             setting.Value = value;
             setting.UpdatedAt = DateTime.UtcNow;
         }
+        else if (IsModelBindingSettingKey(key) &&
+                 !string.Equals(setting.Value, value, StringComparison.Ordinal) &&
+                 await ShouldRepairModelBindingAsync(key, setting.Value, cancellationToken))
+        {
+            setting.Value = value;
+            setting.UpdatedAt = DateTime.UtcNow;
+        }
     }
 
     private async Task ConsolidateTaskScopedLegacyProvidersAsync(CancellationToken cancellationToken)
@@ -483,6 +491,55 @@ public class AiConfigurationMigrationService : IAiConfigurationMigrationService
         return provider == null || provider.IsDeleted || IsTaskScopedLegacyProvider(provider);
     }
 
+    private async Task<bool> ShouldRepairModelBindingAsync(
+        string modelSettingKey,
+        string? modelId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(modelId))
+        {
+            return true;
+        }
+
+        var providerSettingKey = modelSettingKey switch
+        {
+            SystemSettingDefaults.WikiCatalogModelId => SystemSettingDefaults.WikiCatalogProviderId,
+            SystemSettingDefaults.WikiContentModelId => SystemSettingDefaults.WikiContentProviderId,
+            SystemSettingDefaults.WikiTranslationModelId => SystemSettingDefaults.WikiTranslationProviderId,
+            SystemSettingDefaults.GraphifyModelId => SystemSettingDefaults.GraphifyProviderId,
+            _ => null
+        };
+
+        if (providerSettingKey == null)
+        {
+            return false;
+        }
+
+        var providerSetting = await _context.SystemSettings
+            .FirstOrDefaultAsync(s => s.Key == providerSettingKey && !s.IsDeleted, cancellationToken);
+        if (providerSetting == null || string.IsNullOrWhiteSpace(providerSetting.Value))
+        {
+            return true;
+        }
+
+        var provider = await _context.AiProviderConfigs
+            .FirstOrDefaultAsync(p => p.Id == providerSetting.Value, cancellationToken);
+        if (provider == null || provider.IsDeleted)
+        {
+            return true;
+        }
+
+        var model = await _context.AiModelConfigs
+            .FirstOrDefaultAsync(m =>
+                m.ProviderId == provider.Id &&
+                m.ModelId == modelId &&
+                m.IsActive &&
+                !m.IsDeleted,
+                cancellationToken);
+
+        return model == null;
+    }
+
     private AiProviderConfig? FindLocalProviderByName(string name)
     {
         return _context.AiProviderConfigs.Local.FirstOrDefault(p =>
@@ -582,6 +639,14 @@ public class AiConfigurationMigrationService : IAiConfigurationMigrationService
             or SystemSettingDefaults.WikiContentProviderId
             or SystemSettingDefaults.WikiTranslationProviderId
             or SystemSettingDefaults.GraphifyProviderId;
+    }
+
+    private static bool IsModelBindingSettingKey(string key)
+    {
+        return key is SystemSettingDefaults.WikiCatalogModelId
+            or SystemSettingDefaults.WikiContentModelId
+            or SystemSettingDefaults.WikiTranslationModelId
+            or SystemSettingDefaults.GraphifyModelId;
     }
 
     private static bool IsTaskScopedLegacyProvider(AiProviderConfig provider)

--- a/tests/OpenDeepWiki.Tests/Services/AI/AiProviderPresetSeederTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/AI/AiProviderPresetSeederTests.cs
@@ -250,6 +250,79 @@ public class AiProviderPresetSeederTests
         Assert.DoesNotContain(oldProviders.Select(p => p.Id).Skip(1), id => id == targetProviderId);
     }
 
+    [Fact]
+    public async Task MigrateAsync_RepairsStaleModelBindingsButKeepsValidOnes()
+    {
+        await using var context = CreateContext();
+        var endpoint = "https://proxy.example.com/v1";
+        var apiKey = "shared-secret";
+
+        var provider = new AiProviderConfig
+        {
+            Id = Guid.NewGuid().ToString(),
+            Name = "legacy-openai-proxy",
+            DisplayName = "Migrated OpenAI (proxy.example.com)",
+            ProviderType = "OpenAI",
+            BaseUrl = endpoint,
+            ApiKey = apiKey,
+            AuthType = "ApiKey",
+            IsActive = true,
+            SupportsModelDiscovery = true,
+            CreatedAt = DateTime.UtcNow
+        };
+        context.AiProviderConfigs.Add(provider);
+
+        context.AiModelConfigs.Add(new AiModelConfig
+        {
+            Id = Guid.NewGuid().ToString(),
+            ProviderId = provider.Id,
+            ModelId = "valid-model",
+            Name = "Valid Model",
+            ModelType = "chat",
+            ProviderType = "OpenAI",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        context.SystemSettings.AddRange(
+            CreateSetting(SystemSettingDefaults.WikiCatalogProviderId, provider.Id),
+            CreateSetting(SystemSettingDefaults.WikiCatalogModelId, "stale-model"),
+            CreateSetting(SystemSettingDefaults.WikiContentProviderId, provider.Id),
+            CreateSetting(SystemSettingDefaults.WikiContentModelId, "valid-model"));
+        await context.SaveChangesAsync();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AI:Endpoint"] = endpoint,
+                ["AI:ApiKey"] = apiKey,
+                ["AI:RequestType"] = "OpenAI",
+                ["WIKI_CATALOG_MODEL"] = "deepseek-v4-flash",
+                ["WIKI_CONTENT_MODEL"] = "deepseek-v4-flash"
+            })
+            .Build();
+        var migration = new AiConfigurationMigrationService(
+            context,
+            configuration,
+            CreateSeeder(context),
+            NullLogger<AiConfigurationMigrationService>.Instance);
+
+        await migration.MigrateAsync();
+
+        var catalogModelSetting = await context.SystemSettings
+            .SingleAsync(s => s.Key == SystemSettingDefaults.WikiCatalogModelId);
+        var contentModelSetting = await context.SystemSettings
+            .SingleAsync(s => s.Key == SystemSettingDefaults.WikiContentModelId);
+
+        Assert.Equal("deepseek-v4-flash", catalogModelSetting.Value);
+        Assert.Equal("valid-model", contentModelSetting.Value);
+        Assert.NotNull(await context.AiModelConfigs.SingleOrDefaultAsync(m =>
+            m.ProviderId == provider.Id &&
+            m.ModelId == "deepseek-v4-flash" &&
+            m.IsActive &&
+            !m.IsDeleted));
+    }
+
     private static AiProviderPresetSeeder CreateSeeder(IContext context)
     {
         return new AiProviderPresetSeeder(


### PR DESCRIPTION
## Summary

Fixes #385

Two fixes that make `.env`-driven setups with OpenAI-compatible providers (e.g. DeepSeek) work reliably:

### 1. `.env` nested/array keys are now bound correctly

`LoadEnvFile` added `.env` keys to the in-memory configuration with their raw names, so nested keys written in the standard environment-variable form (`RepositoryAnalyzer__AllowedLocalPathRoots__0`) were never bound to `RepositoryAnalyzer:AllowedLocalPathRoots:0`. As a result, local-directory import failed with `当前未配置允许导入的本地目录根路径` even when the whitelist was set in `.env`.

This PR:
- Normalizes `__` to `:` when loading `.env` into configuration.
- Maps `LOCAL_IMPORT_ROOT` to `RepositoryAnalyzer:AllowedLocalPathRoots:0`, so the documented `.env.example` variable actually takes effect.

### 2. Stale wiki model bindings are repaired during AI configuration migration

`UpsertSettingAsync` only repaired `*_PROVIDER_ID` settings, never `*_MODEL_ID` settings. On a fresh install with a non-OpenAI-compatible provider configured through legacy env vars, `SystemSettingDefaults` seeds `WIKI_CATALOG_MODEL_ID=gpt-5-mini` / `WIKI_CONTENT_MODEL_ID=gpt-5.2`, and the migration could not overwrite them. Wiki generation then failed with `AI model 'gpt-5-mini' is not available for provider ...`.

This PR:
- Allows model binding settings to be repaired when the bound provider no longer has the stored model (valid admin-chosen model bindings are preserved).
- Falls back to the provider's `DefaultModelId` (instead of hardcoded `gpt-4o-mini`) when no model is specified in legacy env vars.

## Test plan

- Added `MigrateAsync_RepairsStaleModelBindingsButKeepsValidOnes`.
- Existing `AiProviderPresetSeederTests` suite passes (7/7).
- Manually verified end-to-end with a DeepSeek `deepseek-v4-flash` setup: `.env` local import whitelist works, and wiki catalog/content generation succeeds after migration.
