### PR TITLE
fix: 修复 README 中失效的 Star 历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,4 +278,4 @@ This project is licensed under the MIT License. See [LICENSE](./LICENSE) for det
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=AIDotNet/OpenDeepWiki&type=Date)](https://www.star-history.com/#AIDotNet/OpenDeepWiki&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=AIDotNet/OpenDeepWiki&type=Date)](https://star-history.dera.page/#AIDotNet/OpenDeepWiki&type=date)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -278,4 +278,4 @@ http://localhost:8080/api/mcp?owner=AIDotNet&name=OpenDeepWiki
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=AIDotNet/OpenDeepWiki&type=Date)](https://www.star-history.com/#AIDotNet/OpenDeepWiki&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=AIDotNet/OpenDeepWiki&type=Date)](https://star-history.dera.page/#AIDotNet/OpenDeepWiki&type=date)


### PR DESCRIPTION
README 中的 Star 历史图表目前因 GitHub Stargazer API 限制而无法正常加载，影响项目展示效果。

本次修改将 README.md 与 README.zh-CN.md 中的图表切换到新的数据源，使其恢复可用。