### PR TITLE
fix(ef): bind GitHubAppInstallation Department FK to navigation property

### DIFF
--- a/src/OpenDeepWiki.EFCore/MasterDbContext.cs
+++ b/src/OpenDeepWiki.EFCore/MasterDbContext.cs
@@ -474,7 +474,7 @@ public abstract class MasterDbContext : DbContext, IContext
 
         // GitHubAppInstallation optional FK to Department
         modelBuilder.Entity<GitHubAppInstallation>()
-            .HasOne<Department>()
+            .HasOne(g => g.Department)
             .WithMany()
             .HasForeignKey(g => g.DepartmentId)
             .OnDelete(DeleteBehavior.SetNull);

--- a/tests/OpenDeepWiki.Tests/EFCore/GitHubAppInstallationModelTests.cs
+++ b/tests/OpenDeepWiki.Tests/EFCore/GitHubAppInstallationModelTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using OpenDeepWiki.Entities;
+using OpenDeepWiki.Tests.Services.Wiki;
+using Xunit;
+
+namespace OpenDeepWiki.Tests.EFCore;
+
+public class GitHubAppInstallationModelTests
+{
+    [Fact]
+    public void DepartmentNavigation_UsesSingleExplicitForeignKey()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        using var context = new TestDbContext(options);
+
+        var entityType = context.Model.FindEntityType(typeof(GitHubAppInstallation));
+        Assert.NotNull(entityType);
+
+        var departmentForeignKeys = entityType.GetForeignKeys()
+            .Where(foreignKey => foreignKey.PrincipalEntityType.ClrType == typeof(Department))
+            .ToList();
+
+        var foreignKey = Assert.Single(departmentForeignKeys);
+        Assert.Equal(nameof(GitHubAppInstallation.DepartmentId), Assert.Single(foreignKey.Properties).Name);
+        Assert.Equal(nameof(GitHubAppInstallation.Department), foreignKey.DependentToPrincipal?.Name);
+    }
+}


### PR DESCRIPTION
## Summary
- Bind `GitHubAppInstallation.Department` in `MasterDbContext` instead of `.HasOne<Department>()` without a navigation.
- The existing `[ForeignKey]` navigation plus an anonymous `HasOne` made EF create a shadow `DepartmentId1` column and trip `PendingModelChangesWarning` on startup.
- Add a regression test that the runtime model has exactly one FK to `Department`.

A generated `AddGitHubAppInstallations` migration was **not** included: `dotnet ef migrations add` also dumped a large set of unrelated pending model changes already present on `main`. This PR is the one-line model fix so a later schema migration will not create `DepartmentId1`.

## Test plan
- [ ] `dotnet test tests/OpenDeepWiki.Tests/OpenDeepWiki.Tests.csproj --filter GitHubAppInstallationModelTests`
- [ ] Confirm the test fails on current `main` (two Department FKs) and passes on this branch
- [ ] When generating the next EF migration, verify `GitHubAppInstallations` has a single `DepartmentId` FK and no `DepartmentId1`