### PR TITLE
fix(wiki): normalize LLM Mermaid before persistence

### DIFF
--- a/src/OpenDeepWiki/Agents/Tools/DocTool.cs
+++ b/src/OpenDeepWiki/Agents/Tools/DocTool.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.AI;
 using OpenDeepWiki.EFCore;
 using OpenDeepWiki.Entities;
+using OpenDeepWiki.Services.Wiki;
 
 namespace OpenDeepWiki.Agents.Tools;
 
@@ -72,6 +73,8 @@ content: '# Overview\n\nThis is the overview section...'")]
         {
             return "ERROR: Content cannot be empty. Please provide valid Markdown content for the document.";
         }
+
+        content = MermaidMarkdownNormalizer.Normalize(content);
 
         var catalogPath = ResolveCatalogPath(path);
         if (catalogPath == null)
@@ -182,6 +185,8 @@ content: '\n## Failure Modes\n\nThe service handles ... '")]
         {
             return "ERROR: Content cannot be empty. Please provide valid Markdown content to append.";
         }
+
+        content = MermaidMarkdownNormalizer.Normalize(content);
 
         var catalogPath = ResolveCatalogPath(path);
         if (catalogPath == null)
@@ -344,8 +349,10 @@ newContent: '## New Section\n\nUpdated content here'")]
                 return $"ERROR: The specified content to replace was not found in the document. Please use ReadAsync to see the current content and ensure the text matches exactly.";
             }
 
-            // Replace content
-            docFile.Content = docFile.Content.Replace(oldContent, newContent);
+            // Replace content, then normalize the full document so Mermaid
+            // repairs still apply after a partial edit.
+            docFile.Content = MermaidMarkdownNormalizer.Normalize(
+                docFile.Content.Replace(oldContent, newContent));
             docFile.UpdateTimestamp();
 
             await SaveChangesWithRetryAsync(cancellationToken);

--- a/src/OpenDeepWiki/Services/Admin/AdminRepositoryService.cs
+++ b/src/OpenDeepWiki/Services/Admin/AdminRepositoryService.cs
@@ -1122,7 +1122,7 @@ public class AdminRepositoryService : IAdminRepositoryService
             };
         }
 
-        docFile.Content = request.Content ?? string.Empty;
+        docFile.Content = MermaidMarkdownNormalizer.Normalize(request.Content ?? string.Empty);
         docFile.UpdateTimestamp();
         repository.UpdateTimestamp();
 

--- a/src/OpenDeepWiki/Services/Wiki/MermaidFlowchartIdNormalizer.cs
+++ b/src/OpenDeepWiki/Services/Wiki/MermaidFlowchartIdNormalizer.cs
@@ -1,0 +1,449 @@
+namespace OpenDeepWiki.Services.Wiki;
+
+internal static class MermaidFlowchartIdNormalizer
+{
+    public static string Normalize(string code)
+    {
+        var lines = code.Split('\n');
+        var normalizedLines = new string[lines.Length];
+        var nodeIds = new HashSet<string>(StringComparer.Ordinal);
+        var subgraphs = new List<SubgraphDeclaration>();
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            normalizedLines[i] = line;
+
+            var carriageReturn = line.EndsWith('\r') ? "\r" : string.Empty;
+            var logicalLine = carriageReturn.Length > 0 ? line[..^1] : line;
+
+            if (TryParseExplicitSubgraphDeclaration(i, logicalLine, carriageReturn, out var subgraph))
+            {
+                subgraphs.Add(subgraph);
+                continue;
+            }
+
+            if (StartsWithKeyword(logicalLine, "subgraph"))
+            {
+                continue;
+            }
+
+            CollectNodeIds(logicalLine, nodeIds);
+        }
+
+        if (subgraphs.Count == 0)
+        {
+            return code;
+        }
+
+        var occupiedIds = new HashSet<string>(nodeIds, StringComparer.Ordinal);
+        foreach (var subgraph in subgraphs)
+        {
+            occupiedIds.Add(subgraph.Id);
+        }
+
+        var seenSubgraphIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var subgraph in subgraphs)
+        {
+            var isDuplicateSubgraphId = !seenSubgraphIds.Add(subgraph.Id);
+            if (!nodeIds.Contains(subgraph.Id) && !isDuplicateSubgraphId)
+            {
+                continue;
+            }
+
+            var replacementId = AllocateSubgraphId(subgraph.Id, occupiedIds);
+            occupiedIds.Add(replacementId);
+            normalizedLines[subgraph.LineIndex] = subgraph.Rewrite(replacementId);
+        }
+
+        return string.Join('\n', normalizedLines);
+    }
+
+    private static bool TryParseExplicitSubgraphDeclaration(
+        int lineIndex,
+        string line,
+        string carriageReturn,
+        out SubgraphDeclaration declaration)
+    {
+        declaration = default;
+
+        var index = 0;
+        while (index < line.Length && char.IsWhiteSpace(line[index]))
+        {
+            index++;
+        }
+
+        var keywordStart = index;
+        const string keyword = "subgraph";
+        if (!line.AsSpan(keywordStart).StartsWith(keyword, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        index += keyword.Length;
+        if (index < line.Length && IsIdentifierChar(line[index]))
+        {
+            return false;
+        }
+
+        if (index >= line.Length || !char.IsWhiteSpace(line[index]))
+        {
+            return false;
+        }
+
+        while (index < line.Length && char.IsWhiteSpace(line[index]))
+        {
+            index++;
+        }
+
+        if (index >= line.Length || line[index] == '"')
+        {
+            return false;
+        }
+
+        if (!IsIdentifierStart(line[index]))
+        {
+            return false;
+        }
+
+        var idStart = index;
+        index++;
+        while (index < line.Length && IsIdentifierChar(line[index]))
+        {
+            index++;
+        }
+
+        var remainder = line[index..];
+        var trimmedRemainder = remainder.AsSpan().TrimStart();
+        if (trimmedRemainder.Length == 0 || IsWhitespaceOrComment(trimmedRemainder))
+        {
+            declaration = new SubgraphDeclaration(
+                lineIndex,
+                carriageReturn,
+                line[..idStart],
+                line[idStart..index],
+                remainder,
+                HasExplicitLabel: false);
+            return true;
+        }
+
+        if (trimmedRemainder[0] != '[')
+        {
+            return false;
+        }
+
+        var labelOffset = remainder.Length - trimmedRemainder.Length;
+        if (!TrySkipBalancedRegion(remainder, labelOffset + 1, remainder.Length, '[', ']',
+                out var labelEnd))
+        {
+            return false;
+        }
+
+        if (!IsWhitespaceOrComment(remainder.AsSpan(labelEnd).TrimStart()))
+        {
+            return false;
+        }
+
+        declaration = new SubgraphDeclaration(
+            lineIndex,
+            carriageReturn,
+            line[..idStart],
+            line[idStart..index],
+            remainder,
+            HasExplicitLabel: true);
+        return true;
+    }
+
+    private static void CollectNodeIds(string line, ISet<string> nodeIds)
+    {
+        var scanLimit = FindCommentStart(line);
+        var index = 0;
+
+        while (index < scanLimit)
+        {
+            if (!IsIdentifierStart(line[index]) ||
+                (index > 0 && IsIdentifierChar(line[index - 1])))
+            {
+                index++;
+                continue;
+            }
+
+            var idStart = index;
+            index++;
+            while (index < scanLimit && IsIdentifierChar(line[index]))
+            {
+                index++;
+            }
+
+            if (index >= scanLimit)
+            {
+                continue;
+            }
+
+            var identifier = line[idStart..index];
+            var openerIndex = index;
+            while (openerIndex < scanLimit && IsHorizontalWhitespace(line[openerIndex]))
+            {
+                openerIndex++;
+            }
+
+            if (openerIndex >= scanLimit)
+            {
+                continue;
+            }
+
+            if (line[openerIndex] == '@' && openerIndex + 1 < scanLimit && line[openerIndex + 1] == '{')
+            {
+                nodeIds.Add(identifier);
+                if (!TrySkipBalancedRegion(line, openerIndex + 2, scanLimit, '{', '}',
+                        out var nextIndex))
+                {
+                    break;
+                }
+
+                index = nextIndex;
+                continue;
+            }
+
+            if (!IsNodeOpener(line[openerIndex]))
+            {
+                continue;
+            }
+
+            nodeIds.Add(identifier);
+            if (!TrySkipNodeLabel(line, openerIndex, scanLimit, out var labelEnd))
+            {
+                break;
+            }
+
+            index = labelEnd;
+        }
+    }
+
+    private static bool TrySkipNodeLabel(
+        string line,
+        int openerIndex,
+        int scanLimit,
+        out int nextIndex)
+    {
+        nextIndex = openerIndex;
+        return line[openerIndex] switch
+        {
+            '[' => TrySkipBalancedRegion(line, openerIndex + 1, scanLimit, '[', ']', out nextIndex),
+            '(' => TrySkipBalancedRegion(line, openerIndex + 1, scanLimit, '(', ')', out nextIndex),
+            '{' => TrySkipBalancedRegion(line, openerIndex + 1, scanLimit, '{', '}', out nextIndex),
+            '>' => TrySkipUntilClosingBracket(line, openerIndex + 1, scanLimit, out nextIndex),
+            _ => false
+        };
+    }
+
+    private static bool TrySkipBalancedRegion(
+        string line,
+        int startIndex,
+        int scanLimit,
+        char open,
+        char close,
+        out int nextIndex)
+    {
+        var depth = 1;
+        var found = TryFindOutsideQuotedRegions(
+            line,
+            startIndex,
+            scanLimit,
+            (_, character) =>
+            {
+                if (character == open)
+                {
+                    depth++;
+                    return false;
+                }
+
+                if (character != close)
+                {
+                    return false;
+                }
+
+                depth--;
+                return depth == 0;
+            },
+            out var closingIndex);
+
+        nextIndex = found ? closingIndex + 1 : scanLimit;
+        return found;
+    }
+
+    private static bool TrySkipUntilClosingBracket(
+        string line,
+        int startIndex,
+        int scanLimit,
+        out int nextIndex)
+    {
+        var found = TryFindOutsideQuotedRegions(
+            line,
+            startIndex,
+            scanLimit,
+            (_, character) => character == ']',
+            out var closingIndex);
+
+        nextIndex = found ? closingIndex + 1 : scanLimit;
+        return found;
+    }
+
+    private static int FindCommentStart(string line)
+    {
+        return TryFindOutsideQuotedRegions(
+            line,
+            startIndex: 0,
+            scanLimit: line.Length,
+            (index, character) =>
+                character == '%' &&
+                index + 1 < line.Length &&
+                line[index + 1] == '%',
+            out var commentIndex)
+            ? commentIndex
+            : line.Length;
+    }
+
+    private static bool TryFindOutsideQuotedRegions(
+        string line,
+        int startIndex,
+        int scanLimit,
+        Func<int, char, bool> shouldStop,
+        out int matchIndex)
+    {
+        var inDoubleQuote = false;
+        var inBacktick = false;
+        var escaped = false;
+
+        for (var i = startIndex; i < scanLimit; i++)
+        {
+            var character = line[i];
+            if (inDoubleQuote)
+            {
+                if (character == '"' && !escaped)
+                {
+                    inDoubleQuote = false;
+                }
+
+                escaped = character == '\\' && !escaped;
+                continue;
+            }
+
+            if (inBacktick)
+            {
+                if (character == '`')
+                {
+                    inBacktick = false;
+                }
+
+                continue;
+            }
+
+            if (character == '"')
+            {
+                inDoubleQuote = true;
+                escaped = false;
+                continue;
+            }
+
+            if (character == '`')
+            {
+                inBacktick = true;
+                continue;
+            }
+
+            if (shouldStop(i, character))
+            {
+                matchIndex = i;
+                return true;
+            }
+        }
+
+        matchIndex = scanLimit;
+        return false;
+    }
+
+    private static string AllocateSubgraphId(string originalId, ISet<string> occupiedIds)
+    {
+        var candidate = $"sg_{originalId}";
+        if (!occupiedIds.Contains(candidate))
+        {
+            return candidate;
+        }
+
+        var suffix = 2;
+        while (occupiedIds.Contains($"{candidate}_{suffix}"))
+        {
+            suffix++;
+        }
+
+        return $"{candidate}_{suffix}";
+    }
+
+    private static bool StartsWithKeyword(string line, string keyword)
+    {
+        var index = 0;
+        while (index < line.Length && char.IsWhiteSpace(line[index]))
+        {
+            index++;
+        }
+
+        if (!line.AsSpan(index).StartsWith(keyword, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var end = index + keyword.Length;
+        return end >= line.Length || !IsIdentifierChar(line[end]);
+    }
+
+    private static bool IsWhitespaceOrComment(ReadOnlySpan<char> value)
+    {
+        return value.Length == 0 ||
+               value.StartsWith("%%", StringComparison.Ordinal);
+    }
+
+    private static bool IsIdentifierStart(char character)
+    {
+        return character == '_' ||
+               (character >= 'A' && character <= 'Z') ||
+               (character >= 'a' && character <= 'z');
+    }
+
+    private static bool IsIdentifierChar(char character)
+    {
+        return IsIdentifierStart(character) ||
+               (character >= '0' && character <= '9');
+    }
+
+    private static bool IsNodeOpener(char character)
+    {
+        return character is '[' or '(' or '{' or '>';
+    }
+
+    private static bool IsHorizontalWhitespace(char character)
+    {
+        return character != '\n' &&
+               character != '\r' &&
+               char.IsWhiteSpace(character);
+    }
+
+    private readonly record struct SubgraphDeclaration(
+        int LineIndex,
+        string CarriageReturn,
+        string Prefix,
+        string Id,
+        string Tail,
+        bool HasExplicitLabel)
+    {
+        public string Rewrite(string replacementId)
+        {
+            if (HasExplicitLabel)
+            {
+                return $"{Prefix}{replacementId}{Tail}{CarriageReturn}";
+            }
+
+            return $"{Prefix}{replacementId}[\"{Id}\"]{Tail}{CarriageReturn}";
+        }
+    }
+}

--- a/src/OpenDeepWiki/Services/Wiki/MermaidMarkdownNormalizer.cs
+++ b/src/OpenDeepWiki/Services/Wiki/MermaidMarkdownNormalizer.cs
@@ -1,0 +1,429 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace OpenDeepWiki.Services.Wiki;
+
+/// <summary>
+/// Repairs Mermaid snippets emitted by LLMs before wiki Markdown is persisted.
+/// </summary>
+public static partial class MermaidMarkdownNormalizer
+{
+    private static readonly Regex MermaidFencePattern = new(
+        @"(?<fence>```[ \t]*mermaid[^\r\n]*\r?\n)(?<code>.*?)(?<closing>\r?\n```)",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Normalizes Mermaid code fences inside Markdown while leaving all other
+    /// fenced code blocks and prose untouched.
+    /// </summary>
+    public static string Normalize(string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return content;
+        }
+
+        return MermaidFencePattern.Replace(content, match =>
+        {
+            var code = match.Groups["code"].Value;
+            var normalized = NormalizeMermaidCode(code);
+
+            return $"{match.Groups["fence"].Value}{normalized}{match.Groups["closing"].Value}";
+        });
+    }
+
+    private static string NormalizeMermaidCode(string code)
+    {
+        if (IsFlowchart(code))
+        {
+            return NormalizeFlowchartCode(code);
+        }
+
+        if (IsErDiagram(code))
+        {
+            return NormalizeErDiagramCode(code);
+        }
+
+        if (IsClassDiagram(code))
+        {
+            return NormalizeClassDiagramCode(code);
+        }
+
+        return code;
+    }
+
+    private static string NormalizeFlowchartCode(string code)
+    {
+        var normalized = MermaidFlowchartIdNormalizer.Normalize(code);
+
+        normalized = FlowchartSquareLabelPattern().Replace(normalized, match =>
+        {
+            var label = match.Groups["label"].Value;
+            var trimmed = label.TrimStart();
+
+            // Already quoted/backtick labels are safe. Labels that start with a
+            // shape marker such as "(" should keep their Mermaid shape syntax.
+            if (IsQuotedFlowchartLabel(label) ||
+                trimmed.StartsWith('(') ||
+                trimmed.StartsWith('[') ||
+                trimmed.StartsWith('{'))
+            {
+                return match.Value;
+            }
+
+            return $"{match.Groups["prefix"].Value}[\"{EscapeLabel(label)}\"]";
+        });
+
+        normalized = FlowchartDiamondLabelPattern().Replace(normalized, match =>
+        {
+            var label = match.Groups["label"].Value;
+            if (IsQuotedFlowchartLabel(label))
+            {
+                return match.Value;
+            }
+
+            return $"{match.Groups["prefix"].Value}{{\"{EscapeLabel(label)}\"}}";
+        });
+
+        return FlowchartEdgeLabelPattern().Replace(normalized, match =>
+        {
+            var label = match.Groups["label"].Value;
+
+            if (IsQuotedFlowchartLabel(label))
+            {
+                return match.Value;
+            }
+
+            return $"{match.Groups["operator"].Value}|\"{EscapeLabel(label)}\"|";
+        });
+    }
+
+    private static string NormalizeErDiagramCode(string code)
+    {
+        var lines = code.Split('\n');
+        var normalizedLines = new string[lines.Length];
+        var inEntityBlock = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var carriageReturn = line.EndsWith('\r') ? "\r" : string.Empty;
+            var logicalLine = carriageReturn.Length > 0 ? line[..^1] : line;
+
+            normalizedLines[i] = NormalizeErDiagramLine(logicalLine, ref inEntityBlock) + carriageReturn;
+        }
+
+        return string.Join('\n', normalizedLines);
+    }
+
+    private static string NormalizeClassDiagramCode(string code)
+    {
+        var lines = code.Split('\n');
+        var normalizedLines = new string[lines.Length];
+        var inClassBlock = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var carriageReturn = line.EndsWith('\r') ? "\r" : string.Empty;
+            var logicalLine = carriageReturn.Length > 0 ? line[..^1] : line;
+            var trimmed = logicalLine.Trim();
+
+            if (inClassBlock && trimmed.Equals("end", StringComparison.OrdinalIgnoreCase))
+            {
+                var indent = logicalLine[..(logicalLine.Length - logicalLine.TrimStart().Length)];
+                normalizedLines[i] = $"{indent}}}{carriageReturn}";
+                inClassBlock = false;
+                continue;
+            }
+
+            normalizedLines[i] = line;
+
+            if (!inClassBlock && ClassBlockStartPattern().IsMatch(logicalLine))
+            {
+                inClassBlock = true;
+            }
+            else if (inClassBlock && trimmed.StartsWith("}", StringComparison.Ordinal))
+            {
+                inClassBlock = false;
+            }
+        }
+
+        return string.Join('\n', normalizedLines);
+    }
+
+    private static string NormalizeErDiagramLine(string line, ref bool inEntityBlock)
+    {
+        var trimmed = line.Trim();
+        if (trimmed.Length == 0 || trimmed.StartsWith("%%", StringComparison.Ordinal))
+        {
+            return line;
+        }
+
+        if (!inEntityBlock)
+        {
+            var entityBlock = ErEntityBlockStartPattern().Match(line);
+            if (entityBlock.Success)
+            {
+                inEntityBlock = true;
+
+                return $"{entityBlock.Groups["indent"].Value}{NormalizeIdentifierToken(entityBlock.Groups["entity"].Value)} {{{entityBlock.Groups["suffix"].Value}";
+            }
+
+            return ReplaceDottedIdentifiersOutsideQuotes(line);
+        }
+
+        if (trimmed.StartsWith('}'))
+        {
+            inEntityBlock = false;
+            return line;
+        }
+
+        return NormalizeErAttributeLine(line);
+    }
+
+    private static string NormalizeErAttributeLine(string line)
+    {
+        var indentLength = line.Length - line.TrimStart().Length;
+        var indent = line[..indentLength];
+        var content = line[indentLength..].TrimEnd();
+
+        if (content.Length == 0 || content.StartsWith("%%", StringComparison.Ordinal))
+        {
+            return line;
+        }
+
+        var tokens = ErTokenPattern()
+            .Matches(content)
+            .Select(match => match.Value)
+            .ToList();
+
+        if (tokens.Count == 0 || IsQuotedToken(tokens[0]))
+        {
+            return line;
+        }
+
+        if (IsEnumLikeAttribute(tokens))
+        {
+            var enumValue = NormalizeIdentifierToken(tokens[0]);
+            tokens[0] = enumValue;
+            tokens.Insert(1, $"value_{enumValue}");
+
+            return indent + string.Join(' ', tokens);
+        }
+
+        if (tokens[0].Equals("repeated", StringComparison.OrdinalIgnoreCase) &&
+            tokens.Count >= 3 &&
+            !IsQuotedToken(tokens[1]) &&
+            !IsQuotedToken(tokens[2]))
+        {
+            var originalType = $"{tokens[0]} {tokens[1]}";
+            tokens[0] = $"{NormalizeIdentifierToken(tokens[0])}_{NormalizeIdentifierToken(tokens[1])}";
+            tokens.RemoveAt(1);
+            tokens[1] = NormalizeIdentifierToken(tokens[1]);
+
+            NormalizeRemainingErTokens(tokens, startIndex: 2);
+            AppendOriginalTypeCommentIfNeeded(tokens, originalType);
+
+            return indent + string.Join(' ', tokens);
+        }
+
+        var originalFirstToken = tokens[0];
+        tokens[0] = NormalizeIdentifierToken(tokens[0]);
+
+        if (tokens.Count >= 2 && !IsQuotedToken(tokens[1]))
+        {
+            tokens[1] = NormalizeIdentifierToken(tokens[1]);
+        }
+
+        NormalizeRemainingErTokens(tokens, startIndex: 2);
+        AppendOriginalTypeCommentIfNeeded(tokens, originalFirstToken);
+
+        return indent + string.Join(' ', tokens);
+    }
+
+    private static void NormalizeRemainingErTokens(List<string> tokens, int startIndex)
+    {
+        for (var i = startIndex; i < tokens.Count; i++)
+        {
+            if (!IsQuotedToken(tokens[i]))
+            {
+                tokens[i] = NormalizeIdentifierToken(tokens[i]);
+            }
+        }
+    }
+
+    private static bool IsEnumLikeAttribute(IReadOnlyList<string> tokens)
+    {
+        return tokens.Count == 1 || (tokens.Count == 2 && IsQuotedToken(tokens[1]));
+    }
+
+    private static void AppendOriginalTypeCommentIfNeeded(List<string> tokens, string originalType)
+    {
+        if (!originalType.Contains('.', StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var originalComment = $"original: {EscapeErComment(originalType)}";
+        var lastIndex = tokens.Count - 1;
+
+        if (lastIndex >= 0 && IsQuotedToken(tokens[lastIndex]))
+        {
+            if (tokens[lastIndex].Contains("original:", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            tokens[lastIndex] = tokens[lastIndex].Length == 2
+                ? $"\"{originalComment}\""
+                : $"{tokens[lastIndex][..^1]}; {originalComment}\"";
+            return;
+        }
+
+        tokens.Add($"\"{originalComment}\"");
+    }
+
+    private static string ReplaceDottedIdentifiersOutsideQuotes(string line)
+    {
+        var result = new StringBuilder(line.Length);
+        var segment = new StringBuilder();
+        var inQuote = false;
+        var escaped = false;
+
+        foreach (var character in line)
+        {
+            if (character == '"' && !escaped)
+            {
+                if (!inQuote)
+                {
+                    result.Append(NormalizeIdentifierToken(segment.ToString()));
+                    segment.Clear();
+                    result.Append(character);
+                    inQuote = true;
+                }
+                else
+                {
+                    result.Append(character);
+                    inQuote = false;
+                }
+
+                escaped = false;
+                continue;
+            }
+
+            if (inQuote)
+            {
+                result.Append(character);
+                escaped = character == '\\' && !escaped;
+                if (character != '\\')
+                {
+                    escaped = false;
+                }
+                continue;
+            }
+
+            segment.Append(character);
+        }
+
+        result.Append(NormalizeIdentifierToken(segment.ToString()));
+
+        return result.ToString();
+    }
+
+    private static string NormalizeIdentifierToken(string value)
+    {
+        return DottedErIdentifierPattern().Replace(value, match => match.Value.Replace('.', '_'));
+    }
+
+    private static bool IsQuotedToken(string token)
+    {
+        return token.Length >= 2 && token.StartsWith('"') && token.EndsWith('"');
+    }
+
+    private static bool IsQuotedFlowchartLabel(string label)
+    {
+        var trimmed = label.TrimStart();
+        return trimmed.StartsWith('"') || trimmed.StartsWith('`');
+    }
+
+    private static string EscapeErComment(string comment)
+    {
+        return comment.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    }
+
+    private static bool IsFlowchart(string code)
+    {
+        foreach (var line in code.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0 || trimmed.StartsWith("%%", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return trimmed.StartsWith("flowchart", StringComparison.OrdinalIgnoreCase) ||
+                   trimmed.StartsWith("graph", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    private static bool IsErDiagram(string code)
+    {
+        foreach (var line in code.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0 || trimmed.StartsWith("%%", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return trimmed.StartsWith("erDiagram", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    private static bool IsClassDiagram(string code)
+    {
+        foreach (var line in code.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0 || trimmed.StartsWith("%%", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return trimmed.StartsWith("classDiagram", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    private static string EscapeLabel(string label)
+    {
+        return label.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    }
+
+    [GeneratedRegex(@"(?<prefix>\b[A-Za-z_][A-Za-z0-9_]*\s*)\[(?<label>[^\]\r\n]+)\]")]
+    private static partial Regex FlowchartSquareLabelPattern();
+
+    [GeneratedRegex(@"(?<prefix>\b[A-Za-z_][A-Za-z0-9_]*\s*)\{(?<label>[^{}\r\n]+)\}")]
+    private static partial Regex FlowchartDiamondLabelPattern();
+
+    [GeneratedRegex(@"(?<operator>(?:-{2,}(?:[ox>])?|={2,}>?|-\.{1,}->?))\|(?<label>[^|\r\n]+)\|")]
+    private static partial Regex FlowchartEdgeLabelPattern();
+
+    [GeneratedRegex(@"^\s*class\s+[A-Za-z_][A-Za-z0-9_.-]*\s*\{\s*$")]
+    private static partial Regex ClassBlockStartPattern();
+
+    [GeneratedRegex(@"^(?<indent>\s*)(?<entity>[A-Za-z_][A-Za-z0-9_.-]*)\s*\{(?<suffix>\s*(?:%%.*)?)$")]
+    private static partial Regex ErEntityBlockStartPattern();
+
+    [GeneratedRegex(@"""(?:\\.|[^""\\])*""|\S+")]
+    private static partial Regex ErTokenPattern();
+
+    [GeneratedRegex(@"\b[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+\b")]
+    private static partial Regex DottedErIdentifierPattern();
+}

--- a/src/OpenDeepWiki/Services/Wiki/WikiGenerator.cs
+++ b/src/OpenDeepWiki/Services/Wiki/WikiGenerator.cs
@@ -857,18 +857,47 @@ Please start executing the task.";
      * `stateDiagram-v2` for state machines
    - Mermaid syntax rules:
      * Node IDs must not contain special characters (use letters, numbers, underscores only)
-     * Use quotes for labels with special characters: `A[""Label with (parentheses)""]`
+     * Node IDs and subgraph IDs share one namespace within each Mermaid block
+     * Subgraph IDs must not match any node ID; use `sg_` prefix for subgraphs (e.g., `sg_SetupManager`)
+     * Reusing the same node ID in multiple edges is allowed and is not a duplicate declaration
+     * Edges must reference node IDs, not subgraph IDs
+     * For `erDiagram`, entity identifiers, relationship endpoints, attribute types, and field names must use only letters, numbers, and underscores; never use dots, hyphens, or spaces
+     * If the source type is namespaced or dotted, use a safe alias such as `ci_TaskletContext`, not `ci.TaskletContext`
+     * `erDiagram` attributes must have a single-token type followed by a field name: `string id`, `datetime created_at`
+     * For protobuf/repeated fields, collapse the type to one token and keep the original in the comment: `repeated_TypeName field_name ""original: repeated TypeName""`
+     * For enum values in `erDiagram`, always provide both type and field tokens: `ENUM_VALUE value_ENUM_VALUE ""Description""`
+     * For `classDiagram`, class blocks must close with `}}`, not `end`: `class Foo {{ ... }}`
+     * Do not write `classDiagram` class blocks as `class Foo {{ ... end`; `end` is only for flowchart subgraphs
+     * Always wrap flowchart node, decision/diamond, and subgraph labels in double quotes: `A[""Label with (parentheses)""]`, `Q{{""condition() == true?""}}`
+     * Always wrap flowchart edge labels in double quotes when using pipe syntax: `A -->|""Yes (Claude)""| B`
+     * Labels containing `()`, `/`, `.`, `<br/>`, spaces, non-English text, or punctuation MUST be quoted
      * Escape special characters in labels properly
      * Keep diagrams focused and readable (max 15-20 nodes per diagram)
      * Use subgraph for grouping related components
+   - Example — BAD (subgraph ID collides with node ID; causes render cycle error):
+     ```mermaid
+     flowchart TD
+         subgraph SetupManager[""Setup Manager""]
+             SetupManager[""SetupManager""]
+         end
+         Other --> SetupManager
+     ```
+   - Example — GOOD (subgraph uses `sg_` prefix; edges reference the node):
+     ```mermaid
+     flowchart TD
+         subgraph sg_SetupManager[""Setup Manager""]
+             SetupManager[""SetupManager""]
+         end
+         Other --> SetupManager
+     ```
    - Example valid Mermaid syntax:
      ```mermaid
      flowchart TD
-         subgraph Core[""Core Components""]
-             A[Service Layer] --> B[Repository]
+         subgraph sg_Core[""Core Components""]
+             A[""Service Layer""] --> B[""Repository""]
              B --> C[(Database)]
          end
-         D[API Controller] --> A
+         D[""API Controller""] -->|""calls (HTTP)""| A
      ```
 
 5. **Content Quality Requirements**
@@ -1867,6 +1896,7 @@ Source grounding:
 
                     // 清理 <think> 标签
                     translatedContent = RemoveThinkTags(translatedContent);
+                    translatedContent = MermaidMarkdownNormalizer.Normalize(translatedContent);
 
                     var newDocFile = new DocFile
                     {

--- a/src/OpenDeepWiki/prompts/content-generator.md
+++ b/src/OpenDeepWiki/prompts/content-generator.md
@@ -679,17 +679,74 @@ flowchart TD
 ```
 ✅ CORRECT Mermaid Syntax:
 - Node IDs: Use only letters, numbers, underscores (A1, ServiceLayer, auth_handler)
-- Labels with special chars: A["Label with (parentheses)"]
-- Subgraph labels: subgraph Name["Display Label"]
-- Arrow types: --> (solid), -.-> (dotted), ==> (thick), --text--> (labeled)
+- Unique IDs: Node IDs and subgraph IDs share one namespace within each Mermaid block
+- Subgraph IDs: Must not match any node ID; use `sg_` prefix (e.g., `sg_SetupManager`)
+- Edge targets: Reference node IDs only; reusing the same node ID in multiple edges is allowed and is not a duplicate declaration
+- Flowchart node labels: Always use quotes, e.g. A["Label with (parentheses)"]
+- Flowchart decision/diamond labels: Always use quotes, e.g. Q{"condition() && value > 0?"}
+- Edge labels with pipe syntax: A -->|"Yes (Claude)"| B
+- Subgraph labels: subgraph sg_Name["Display Label"]
+- Class diagram blocks: class Foo { ... } (close with `}`, never `end`)
+- Arrow types: --> (solid), -.-> (dotted), ==> (thick), -->|"label"| (labeled)
 - Direction: TD (top-down), LR (left-right), BT (bottom-top), RL (right-left)
+- ER identifiers: Use safe aliases with letters, numbers, underscores only (ci_TaskletContext, not ci.TaskletContext)
+- ER attributes: Use exactly one type token followed by one field token (string id, repeated_Tag tags)
+- ER repeated/protobuf fields: Use repeated_TypeName field_name "original: repeated TypeName"
+- ER enum values: Use ENUM_VALUE value_ENUM_VALUE "Description"
 
 ❌ INVALID Mermaid Syntax (will break rendering):
+- Subgraph ID equals a node ID in the same block (causes render cycle errors)
+- Edges targeting subgraph IDs instead of node IDs
 - Node IDs with spaces: My Node --> Other Node
 - Node IDs with special chars: Auth-Service --> DB.Connection
 - Unquoted labels with special chars: A[Label (broken)]
+- Unquoted labels that look simple but later break when edited: A[Process Request]
+- Unquoted decision labels with expressions: Q{items.filter(x).length > 0?}
+- Unquoted edge labels with special chars: A -->|Yes (Claude)| B
+- classDiagram class block closed with `end`: class Foo { ... end
+- ER identifiers with dots/hyphens/spaces: ci.TaskletContext ||--o{ api-key Config
+- ER multi-token attribute types: repeated string tags
+- ER enum values without field names: NONE "No value"
 - Missing end for subgraph
 - Nested quotes without escaping
+```
+
+**SetupManager ID collision — BAD vs GOOD:**
+
+```mermaid
+flowchart TD
+    subgraph SetupManager["Setup Manager"]
+        SetupManager["SetupManager"]
+    end
+    Other --> SetupManager
+```
+
+❌ BAD — `SetupManager` is both subgraph ID and node ID; Mermaid fails with a parent/child cycle.
+
+```mermaid
+flowchart TD
+    subgraph sg_SetupManager["Setup Manager"]
+        SetupManager["SetupManager"]
+    end
+    Other --> SetupManager
+```
+
+✅ GOOD — subgraph uses `sg_SetupManager`; edges reference the node `SetupManager`.
+
+For `classDiagram`, copy this block shape exactly. Each class block closes
+with `}` on its own line; reserve `end` only for flowchart subgraphs:
+
+```mermaid
+classDiagram
+    class Client {
+        +dependency: Api
+    }
+
+    class Api {
+        +execute() Result
+    }
+
+    Client --> Api
 ```
 
 ### 7.4 Architecture Diagram Template

--- a/src/OpenDeepWiki/prompts/incremental-updater.md
+++ b/src/OpenDeepWiki/prompts/incremental-updater.md
@@ -44,6 +44,10 @@
    - If a file was deleted, verify before removing documentation
    - Mark deprecated features clearly rather than silently removing
    - Update cross-references that point to removed content
+
+8. **MERMAID UNIQUE ID RULES**
+   - When creating or editing Mermaid diagrams, node IDs and subgraph IDs must be unique within each block (use `sg_` prefix for subgraphs)
+   - Verify subgraph and node IDs do not overlap before saving
 </constraints>
 
 ---

--- a/tests/OpenDeepWiki.Tests/Services/Wiki/MermaidMarkdownNormalizerTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/Wiki/MermaidMarkdownNormalizerTests.cs
@@ -1,0 +1,862 @@
+using OpenDeepWiki.Services.Wiki;
+using Xunit;
+
+namespace OpenDeepWiki.Tests.Services.Wiki;
+
+public class MermaidMarkdownNormalizerTests
+{
+    [Fact]
+    public void Normalize_QuotesFlowchartSquareLabelsWithSpecialCharacters()
+    {
+        var input =
+            "## Architecture\n\n" +
+            "```mermaid\n" +
+            "flowchart TD\n" +
+            "    Execute[execute()<br/>Main orchestration]\n" +
+            "    Source[src/tasklet.ts<br/>Tasklet]\n" +
+            "    Execute --> Source\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected =
+            "## Architecture\n\n" +
+            "```mermaid\n" +
+            "flowchart TD\n" +
+            "    Execute[\"execute()<br/>Main orchestration\"]\n" +
+            "    Source[\"src/tasklet.ts<br/>Tasklet\"]\n" +
+            "    Execute --> Source\n" +
+            "```\n";
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_LeavesAlreadyQuotedLabelsUnchanged()
+    {
+        var input =
+            "```mermaid\n" +
+            "flowchart LR\n" +
+            "    A[\"execute()<br/>Run\"] --> B[\"Done\"]\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Normalize_QuotesFlowchartEdgeLabelsWithSpecialCharacters()
+    {
+        var input =
+            "```mermaid\n" +
+            "flowchart TD\n" +
+            "    C -->|Да (Claude)| D[\"Настроить MCP серверы\"]\n" +
+            "    D -->|Нет / retry| E[Continue]\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected =
+            "```mermaid\n" +
+            "flowchart TD\n" +
+            "    C -->|\"Да (Claude)\"| D[\"Настроить MCP серверы\"]\n" +
+            "    D -->|\"Нет / retry\"| E[\"Continue\"]\n" +
+            "```\n";
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_LeavesAlreadyQuotedEdgeLabelsUnchanged()
+    {
+        var input =
+            "```mermaid\n" +
+            "flowchart LR\n" +
+            "    A -->|\"Да (Claude)\"| B[\"Done\"]\n" +
+            "    B -.->|`retry (safe)`| C[\"Retry\"]\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Normalize_QuotesFlowchartDiamondLabelsWithExpressions()
+    {
+        var input =
+            "```mermaid\n" +
+            "flowchart TD\n" +
+            "    A[\"Input: tokens[], excludeKeys\"] --> B{filtered = tokens.filter<br/>!excludeKeys.has(t.tokenKey)}\n" +
+            "    B --> C{filtered.length > 0?}\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected =
+            "```mermaid\n" +
+            "flowchart TD\n" +
+            "    A[\"Input: tokens[], excludeKeys\"] --> B{\"filtered = tokens.filter<br/>!excludeKeys.has(t.tokenKey)\"}\n" +
+            "    B --> C{\"filtered.length > 0?\"}\n" +
+            "```\n";
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_LeavesAlreadyQuotedDiamondLabelsUnchanged()
+    {
+        var input =
+            "```mermaid\n" +
+            "flowchart TD\n" +
+            "    A --> B{\"filtered = tokens.filter<br/>!excludeKeys.has(t.tokenKey)\"}\n" +
+            "    B --> C{`ready (safe)?`}\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Normalize_QuotesFlowchartEdgeLabelsAcrossArrowTypes()
+    {
+        var input =
+            "```mermaid\n" +
+            "graph TD\n" +
+            "    A ---|Plain| B\n" +
+            "    B -.->|Retry (soft)| C\n" +
+            "    C ==>|Done / final| D\n" +
+            "    E --o|Maybe (optional)| F\n" +
+            "    G --x|Rejected (hard)| H\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected =
+            "```mermaid\n" +
+            "graph TD\n" +
+            "    A ---|\"Plain\"| B\n" +
+            "    B -.->|\"Retry (soft)\"| C\n" +
+            "    C ==>|\"Done / final\"| D\n" +
+            "    E --o|\"Maybe (optional)\"| F\n" +
+            "    G --x|\"Rejected (hard)\"| H\n" +
+            "```\n";
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_PreservesFlowchartShapeSyntax()
+    {
+        var input =
+            "```mermaid\n" +
+            "flowchart TD\n" +
+            "    Db[(Database)]\n" +
+            "    Decision{Ready?}\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected =
+            "```mermaid\n" +
+            "flowchart TD\n" +
+            "    Db[(Database)]\n" +
+            "    Decision{\"Ready?\"}\n" +
+            "```\n";
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_RewritesErDottedIdentifiersInRelationshipsAndAttributes()
+    {
+        var input =
+            "```mermaid\n" +
+            "erDiagram\n" +
+            "    ci.TaskletContext ||--o{ ci.TaskletConfig : \"has configs\"\n" +
+            "    ci.TaskletContext {\n" +
+            "        ci.TaskletConfig active_config \"current config\"\n" +
+            "    }\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected =
+            "```mermaid\n" +
+            "erDiagram\n" +
+            "    ci_TaskletContext ||--o{ ci_TaskletConfig : \"has configs\"\n" +
+            "    ci_TaskletContext {\n" +
+            "        ci_TaskletConfig active_config \"current config; original: ci.TaskletConfig\"\n" +
+            "    }\n" +
+            "```\n";
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_RewritesErRepeatedAttributeTypes()
+    {
+        var input =
+            "```mermaid\n" +
+            "erDiagram\n" +
+            "    CONFIG {\n" +
+            "        repeated AnthropicApiKeyConfig anthropic_api_keys\n" +
+            "        repeated string tags \"tag values\"\n" +
+            "        repeated ci.TaskletContext contexts\n" +
+            "    }\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected =
+            "```mermaid\n" +
+            "erDiagram\n" +
+            "    CONFIG {\n" +
+            "        repeated_AnthropicApiKeyConfig anthropic_api_keys\n" +
+            "        repeated_string tags \"tag values\"\n" +
+            "        repeated_ci_TaskletContext contexts \"original: repeated ci.TaskletContext\"\n" +
+            "    }\n" +
+            "```\n";
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_AddsFieldNamesForEnumLikeErAttributes()
+    {
+        var input =
+            "```mermaid\n" +
+            "erDiagram\n" +
+            "    STATUS {\n" +
+            "        NONE \"No value\"\n" +
+            "        ACTIVE\n" +
+            "    }\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected =
+            "```mermaid\n" +
+            "erDiagram\n" +
+            "    STATUS {\n" +
+            "        NONE value_NONE \"No value\"\n" +
+            "        ACTIVE value_ACTIVE\n" +
+            "    }\n" +
+            "```\n";
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_ReplacesClassDiagramEndWithClosingBrace()
+    {
+        var input =
+            "```mermaid\n" +
+            "classDiagram\n" +
+            "    class ArcanumClient {\n" +
+            "        +readonly diffs: DiffsAPI\n" +
+            "    end\n" +
+            "\n" +
+            "    class DiffsAPI {\n" +
+            "        <<interface>>\n" +
+            "        +get(id: number, options?: FieldsOptions): Promise~Diff~\n" +
+            "    end\n" +
+            "\n" +
+            "    ArcanumClient --> DiffsAPI\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected =
+            "```mermaid\n" +
+            "classDiagram\n" +
+            "    class ArcanumClient {\n" +
+            "        +readonly diffs: DiffsAPI\n" +
+            "    }\n" +
+            "\n" +
+            "    class DiffsAPI {\n" +
+            "        <<interface>>\n" +
+            "        +get(id: number, options?: FieldsOptions): Promise~Diff~\n" +
+            "    }\n" +
+            "\n" +
+            "    ArcanumClient --> DiffsAPI\n" +
+            "```\n";
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_LeavesValidClassDiagramBracesUnchanged()
+    {
+        var input =
+            "```mermaid\n" +
+            "classDiagram\n" +
+            "    class DiffsAPI {\n" +
+            "        <<interface>>\n" +
+            "        +get(id: number): Promise~Diff~\n" +
+            "    }\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Normalize_ReplacesClassDiagramEndWithDifferentCaseAndWhitespace()
+    {
+        var input =
+            "```mermaid\r\n" +
+            "classDiagram\r\n" +
+            "    class Client {\r\n" +
+            "        +api: ApiClient\r\n" +
+            "    End   \r\n" +
+            "\r\n" +
+            "    class ApiClient {\r\n" +
+            "        +execute() Response\r\n" +
+            "    END\r\n" +
+            "```\r\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected =
+            "```mermaid\r\n" +
+            "classDiagram\r\n" +
+            "    class Client {\r\n" +
+            "        +api: ApiClient\r\n" +
+            "    }\r\n" +
+            "\r\n" +
+            "    class ApiClient {\r\n" +
+            "        +execute() Response\r\n" +
+            "    }\r\n" +
+            "```\r\n";
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_ReplacesClassDiagramEndWhenMixedWithValidBraces()
+    {
+        var input =
+            "```mermaid\n" +
+            "classDiagram\n" +
+            "    class Existing {\n" +
+            "        +id: string\n" +
+            "    }\n" +
+            "\n" +
+            "    class Generated {\n" +
+            "        +name: string\n" +
+            "    end\n" +
+            "\n" +
+            "    Existing --> Generated\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected =
+            "```mermaid\n" +
+            "classDiagram\n" +
+            "    class Existing {\n" +
+            "        +id: string\n" +
+            "    }\n" +
+            "\n" +
+            "    class Generated {\n" +
+            "        +name: string\n" +
+            "    }\n" +
+            "\n" +
+            "    Existing --> Generated\n" +
+            "```\n";
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_DoesNotReplaceFlowchartSubgraphEnd()
+    {
+        var input =
+            "```mermaid\n" +
+            "flowchart TD\n" +
+            "    subgraph Core[\"Core\"]\n" +
+            "        A[\"Service\"] --> B[\"Repository\"]\n" +
+            "    end\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        Assert.Contains("    end\n", result);
+        Assert.DoesNotContain("    }\n", result);
+    }
+
+    [Fact]
+    public void Normalize_DoesNotTouchNonMermaidCodeBlocks()
+    {
+        var input =
+            "```typescript\n" +
+            "const value = items[0];\n" +
+            "```\n";
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Normalize_RenamesCollidingSubgraphIdForSetupManagerRepro()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph SetupManager",
+            "        Start --> SetupManager[setup_manager.go]",
+            "        Bootstrap[Start] --> SetupManager[setup_manager.go] --> Result[Done]",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph sg_SetupManager[\"SetupManager\"]",
+            "        Start --> SetupManager[\"setup_manager.go\"]",
+            "        Bootstrap[\"Start\"] --> SetupManager[\"setup_manager.go\"] --> Result[\"Done\"]",
+            "    end");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_LeavesCanonicalLabeledSubgraphWithoutCollisionUnchanged()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "graph TD",
+            "    subgraph Core[\"Core\"]",
+            "        A[\"Service\"] --> B[\"Repository\"]",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Normalize_DoesNotRewriteTitleOnlySubgraphWithParenthesizedTitle()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Setup Manager(v2)",
+            "        A[\"Call Manager(x)\"] --> B[\"Done\"] %% safe comment",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Normalize_DoesNotTreatUnicodeLikeSubgraphsOrNodesAsAsciiIdentifiers()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Менеджер",
+            "        Старт --> Менеджер[данные]",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Theory]
+    [InlineData("class")]
+    [InlineData("style")]
+    [InlineData("click")]
+    [InlineData("linkStyle")]
+    public void Normalize_DetectsKeywordLikeNodeIdsWhenTheyAreRealNodeDeclarations(string nodeId)
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            $"    subgraph {nodeId}",
+            $"        {nodeId}[real node] --> End",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            $"    subgraph sg_{nodeId}[\"{nodeId}\"]",
+            $"        {nodeId}[\"real node\"] --> End",
+            "    end");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_DoesNotTreatSubgraphWithTrailingTextAfterClosedLabelAsExplicitId()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Core[\"API ] Layer\"] trailing",
+            "        Start --> Core[worker]",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Core[\"API ] Layer\"] trailing",
+            "        Start --> Core[\"worker\"]",
+            "    end");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_DoesNotTreatSubgraphWithUnclosedLabelAsExplicitId()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Core[\"API\"",
+            "        Start --> Core[worker]",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Core[\"API\"",
+            "        Start --> Core[\"worker\"]",
+            "    end");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_DetectsCollidingNodeDeclarationsWithHorizontalWhitespaceBeforeOpeners()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Square",
+            "        Start --> Square [plain] --> Tail[done]",
+            "    end",
+            "    subgraph Round",
+            "        Root --> Round\t([round])",
+            "    end",
+            "    subgraph Diamond",
+            "        Root --> Diamond \t{decision}",
+            "    end",
+            "    subgraph Flag",
+            "        Root --> Flag \t>flag]",
+            "    end",
+            "    subgraph Json",
+            "        Root --> Json \t@{ shape: rect, label: \"json\" }",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph sg_Square[\"Square\"]",
+            "        Start --> Square [\"plain\"] --> Tail[\"done\"]",
+            "    end",
+            "    subgraph sg_Round[\"Round\"]",
+            "        Root --> Round\t([round])",
+            "    end",
+            "    subgraph sg_Diamond[\"Diamond\"]",
+            "        Root --> Diamond \t{\"decision\"}",
+            "    end",
+            "    subgraph sg_Flag[\"Flag\"]",
+            "        Root --> Flag \t>flag]",
+            "    end",
+            "    subgraph sg_Json[\"Json\"]",
+            "        Root --> Json \t@{ shape: rect, label: \"json\" }",
+            "    end");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_DetectsCollidingNodeDeclarationsAcrossRepresentativeShapeFamilies()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Square",
+            "        Root --> Square[plain]",
+            "    end",
+            "    subgraph Stadium",
+            "        Root --> Stadium([stadium])",
+            "    end",
+            "    subgraph DoubleCircle",
+            "        Root --> DoubleCircle((double))",
+            "    end",
+            "    subgraph TripleCircle",
+            "        Root --> TripleCircle(((triple)))",
+            "    end",
+            "    subgraph Diamond",
+            "        Root --> Diamond{decision}",
+            "    end",
+            "    subgraph Hexagon",
+            "        Root --> Hexagon{{hex}}",
+            "    end",
+            "    subgraph Subroutine",
+            "        Root --> Subroutine[[subroutine]]",
+            "    end",
+            "    subgraph Cylinder",
+            "        Root --> Cylinder[(storage)]",
+            "    end",
+            "    subgraph SlashForward",
+            "        Root --> SlashForward[/input/]",
+            "    end",
+            "    subgraph SlashBackward",
+            "        Root --> SlashBackward[\\output\\]",
+            "    end",
+            "    subgraph Trapezoid",
+            "        Root --> Trapezoid[/input\\]",
+            "    end",
+            "    subgraph TrapezoidAlt",
+            "        Root --> TrapezoidAlt[\\output/]",
+            "    end",
+            "    subgraph Flag",
+            "        Root --> Flag>flag]",
+            "    end",
+            "    subgraph Json",
+            "        Root --> Json@{ shape: rect, label: \"json\" }",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph sg_Square[\"Square\"]",
+            "        Root --> Square[\"plain\"]",
+            "    end",
+            "    subgraph sg_Stadium[\"Stadium\"]",
+            "        Root --> Stadium([stadium])",
+            "    end",
+            "    subgraph sg_DoubleCircle[\"DoubleCircle\"]",
+            "        Root --> DoubleCircle((double))",
+            "    end",
+            "    subgraph sg_TripleCircle[\"TripleCircle\"]",
+            "        Root --> TripleCircle(((triple)))",
+            "    end",
+            "    subgraph sg_Diamond[\"Diamond\"]",
+            "        Root --> Diamond{\"decision\"}",
+            "    end",
+            "    subgraph sg_Hexagon[\"Hexagon\"]",
+            "        Root --> Hexagon{{hex}}",
+            "    end",
+            "    subgraph sg_Subroutine[\"Subroutine\"]",
+            "        Root --> Subroutine[[subroutine]]",
+            "    end",
+            "    subgraph sg_Cylinder[\"Cylinder\"]",
+            "        Root --> Cylinder[(storage)]",
+            "    end",
+            "    subgraph sg_SlashForward[\"SlashForward\"]",
+            "        Root --> SlashForward[\"/input/\"]",
+            "    end",
+            "    subgraph sg_SlashBackward[\"SlashBackward\"]",
+            "        Root --> SlashBackward[\"\\\\output\\\\\"]",
+            "    end",
+            "    subgraph sg_Trapezoid[\"Trapezoid\"]",
+            "        Root --> Trapezoid[\"/input\\\\\"]",
+            "    end",
+            "    subgraph sg_TrapezoidAlt[\"TrapezoidAlt\"]",
+            "        Root --> TrapezoidAlt[\"\\\\output/\"]",
+            "    end",
+            "    subgraph sg_Flag[\"Flag\"]",
+            "        Root --> Flag>flag]",
+            "    end",
+            "    subgraph sg_Json[\"Json\"]",
+            "        Root --> Json@{ shape: rect, label: \"json\" }",
+            "    end");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_DoesNotTreatLabelsOrCommentsAsNodeDeclarations()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Manager",
+            "        A[Call Manager(x)] --> B[\"Done\"] %% Manager(x) ignored",
+            "        C[\"Quoted Manager(x)\"]",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Manager",
+            "        A[\"Call Manager(x)\"] --> B[\"Done\"] %% Manager(x) ignored",
+            "        C[\"Quoted Manager(x)\"]",
+            "    end");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_StopsScanningLineWhenNodeLabelIsUnclosed()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Manager",
+            "        A[Call Manager(x)",
+            "        B[\"Done\"]",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Normalize_PreservesExplicitSubgraphLabelWhenRenamingCollision()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph SetupManager [\"Setup Manager\"]",
+            "        Start --> SetupManager[setup_manager.go]",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph sg_SetupManager [\"Setup Manager\"]",
+            "        Start --> SetupManager[\"setup_manager.go\"]",
+            "    end");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_UsesNextAvailableSuffixWhenSgPrefixIsOccupied()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    sg_SetupManager[Reserved]",
+            "    subgraph SetupManager",
+            "        Start --> SetupManager[setup_manager.go]",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    sg_SetupManager[\"Reserved\"]",
+            "    subgraph sg_SetupManager_2[\"SetupManager\"]",
+            "        Start --> SetupManager[\"setup_manager.go\"]",
+            "    end");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_RenamesNestedRepeatedExplicitSubgraphIdsDeterministically()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Service",
+            "        subgraph Service",
+            "            Inner[\"Inner\"]",
+            "        end",
+            "    end");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph Service",
+            "        subgraph sg_Service[\"Service\"]",
+            "            Inner[\"Inner\"]",
+            "        end",
+            "    end");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_LeavesStyleClassClickAndLinkStyleDirectivesUnchanged()
+    {
+        var input = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph SetupManager",
+            "        Start --> SetupManager[setup_manager.go]",
+            "    end",
+            "    style SetupManager fill:#f9f,stroke:#333",
+            "    class SetupManager hot",
+            "    click SetupManager href \"https://example.test/setup\"",
+            "    linkStyle default stroke:#333");
+
+        var result = MermaidMarkdownNormalizer.Normalize(input);
+
+        var expected = MermaidBlock(
+            "\n",
+            "flowchart TD",
+            "    subgraph sg_SetupManager[\"SetupManager\"]",
+            "        Start --> SetupManager[\"setup_manager.go\"]",
+            "    end",
+            "    style SetupManager fill:#f9f,stroke:#333",
+            "    class SetupManager hot",
+            "    click SetupManager href \"https://example.test/setup\"",
+            "    linkStyle default stroke:#333");
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_PreservesCrLfAndIsIdempotentForSubgraphRename()
+    {
+        var input = MermaidBlock(
+            "\r\n",
+            "flowchart TD",
+            "    subgraph SetupManager",
+            "        Start --> SetupManager[setup_manager.go]",
+            "    end");
+
+        var normalizedOnce = MermaidMarkdownNormalizer.Normalize(input);
+        var normalizedTwice = MermaidMarkdownNormalizer.Normalize(normalizedOnce);
+
+        var expected = MermaidBlock(
+            "\r\n",
+            "flowchart TD",
+            "    subgraph sg_SetupManager[\"SetupManager\"]",
+            "        Start --> SetupManager[\"setup_manager.go\"]",
+            "    end");
+
+        Assert.Equal(expected, normalizedOnce);
+        Assert.Equal(expected, normalizedTwice);
+    }
+
+    private static string MermaidBlock(string lineEnding, params string[] lines)
+    {
+        return "```mermaid" + lineEnding +
+               string.Join(lineEnding, lines) + lineEnding +
+               "```" + lineEnding;
+    }
+}


### PR DESCRIPTION
## Summary
- Add a server-side Mermaid normalizer that repairs common LLM syntax issues in flowchart, ER, and class diagrams before wiki Markdown is saved.
- Rename colliding subgraph IDs to `sg_*` so Mermaid does not fail with parent/child cycle errors.
- Quote unquoted flowchart node, diamond, and edge labels that contain special characters.
- Wire normalization into `DocTool` writes/appends/edits, admin document updates, and wiki translation.
- Strengthen content-generator and incremental-updater prompts with unique-ID and quoting rules.

## Test plan
- [ ] `dotnet test tests/OpenDeepWiki.Tests/OpenDeepWiki.Tests.csproj --filter Mermaid`
- [ ] Generate a wiki page whose flowchart has unquoted labels with `()` / `<br/>` and confirm it renders
- [ ] Generate a page where a subgraph ID matches a node ID and confirm there is no Mermaid cycle error
- [ ] Edit a document in admin and confirm Mermaid in the saved body is normalized