### PR TITLE
fix(agents): coerce null tool-call arguments to empty JSON object

### DIFF
--- a/src/OpenDeepWiki/Agents/LoggingHttpHandler.cs
+++ b/src/OpenDeepWiki/Agents/LoggingHttpHandler.cs
@@ -1,4 +1,7 @@
 using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Serilog;
 
 namespace OpenDeepWiki.Agents;
@@ -25,6 +28,8 @@ public class LoggingHttpHandler(HttpMessageHandler innerHandler) : DelegatingHan
         var requestId = Guid.NewGuid().ToString("N")[..8];
         var startTime = DateTime.UtcNow;
         var aiContext = AiExecutionScope.Current?.ToSummary() ?? "tag=unlabeled | desc=未标记AI请求";
+
+        await NormalizeToolCallArgumentsAsync(requestId, request, cancellationToken);
 
         Logger.Information(
             "[{RequestId}] [{AiContext}] >>> Request: {Method} {RequestUri}",
@@ -117,6 +122,135 @@ public class LoggingHttpHandler(HttpMessageHandler innerHandler) : DelegatingHan
         }
 
         return response!;
+    }
+
+    /// <summary>
+    /// Rewrites <c>messages[].tool_calls[].function.arguments</c> values that are
+    /// null / JSON null / empty into <c>"{}"</c>.
+    /// <para>
+    /// Zero-parameter tools (e.g. <c>ReadCatalog</c>) are often called with no
+    /// arguments. The OpenAI .NET serializer then re-emits that history entry as
+    /// <c>"arguments":"null"</c>. Strict JSON chat backends (for example MiniMax)
+    /// reject that payload. Normalizing to an empty JSON object keeps the request
+    /// valid for every provider.
+    /// </para>
+    /// <para>
+    /// The JSON DOM is mutated field-by-field rather than via string replace, so
+    /// document or catalog content that happens to contain the literal text
+    /// <c>"arguments":"null"</c> is never corrupted. Best-effort: any failure
+    /// leaves the request untouched.
+    /// </para>
+    /// </summary>
+    private static async Task NormalizeToolCallArgumentsAsync(
+        string requestId,
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (request.Content == null)
+            {
+                return;
+            }
+
+            var mediaType = request.Content.Headers.ContentType?.MediaType;
+            if (mediaType != null && !mediaType.Contains("json", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var body = await request.Content.ReadAsStringAsync(cancellationToken);
+            if (body.Length == 0 || !body.Contains("\"tool_calls\"", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            JsonNode? root;
+            try
+            {
+                root = JsonNode.Parse(body);
+            }
+            catch (JsonException)
+            {
+                return;
+            }
+
+            if (root is not JsonObject rootObject || rootObject["messages"] is not JsonArray messages)
+            {
+                return;
+            }
+
+            var fixedCount = 0;
+            foreach (var message in messages)
+            {
+                if (message is not JsonObject messageObject ||
+                    messageObject["tool_calls"] is not JsonArray toolCalls)
+                {
+                    continue;
+                }
+
+                foreach (var toolCall in toolCalls)
+                {
+                    if (toolCall is not JsonObject toolCallObject ||
+                        toolCallObject["function"] is not JsonObject functionObject)
+                    {
+                        continue;
+                    }
+
+                    if (NeedsEmptyArguments(functionObject["arguments"]))
+                    {
+                        functionObject["arguments"] = "{}";
+                        fixedCount++;
+                    }
+                }
+            }
+
+            if (fixedCount == 0)
+            {
+                return;
+            }
+
+            var rewritten = root.ToJsonString();
+            request.Content = new StringContent(rewritten, Encoding.UTF8, mediaType ?? "application/json");
+
+            Logger.Information(
+                "[{RequestId}] Normalized {FixedCount} tool-call argument(s) from null/empty to '{{}}'",
+                requestId,
+                fixedCount);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(
+                ex,
+                "[{RequestId}] Tool-call argument normalization skipped",
+                requestId);
+        }
+    }
+
+    /// <summary>
+    /// True when a tool-call <c>arguments</c> node is null, JSON null, or a
+    /// string that is empty/whitespace or the literal <c>"null"</c>.
+    /// </summary>
+    public static bool NeedsEmptyArguments(JsonNode? argumentsNode)
+    {
+        if (argumentsNode is null)
+        {
+            return true;
+        }
+
+        if (argumentsNode.GetValueKind() == JsonValueKind.Null)
+        {
+            return true;
+        }
+
+        if (argumentsNode.GetValueKind() == JsonValueKind.String)
+        {
+            var value = argumentsNode.GetValue<string>();
+            return string.IsNullOrWhiteSpace(value) ||
+                   string.Equals(value.Trim(), "null", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
     }
 
     private static bool ShouldRetry(HttpStatusCode statusCode)

--- a/tests/OpenDeepWiki.Tests/Agents/LoggingHttpHandlerTests.cs
+++ b/tests/OpenDeepWiki.Tests/Agents/LoggingHttpHandlerTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using OpenDeepWiki.Agents;
+using Xunit;
+
+namespace OpenDeepWiki.Tests.Agents;
+
+public class LoggingHttpHandlerTests
+{
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("null", true)]
+    [InlineData("NULL", true)]
+    [InlineData("", true)]
+    [InlineData("   ", true)]
+    [InlineData("{}", false)]
+    [InlineData("{\"path\":\"x\"}", false)]
+    public void NeedsEmptyArguments_DetectsNullAndEmptyValues(string? value, bool expected)
+    {
+        JsonNode? node = value is null ? null : JsonValue.Create(value);
+        Assert.Equal(expected, LoggingHttpHandler.NeedsEmptyArguments(node));
+    }
+
+    [Fact]
+    public void NeedsEmptyArguments_TreatsJsonNullAsEmpty()
+    {
+        var node = JsonNode.Parse("null");
+        Assert.True(LoggingHttpHandler.NeedsEmptyArguments(node));
+    }
+
+    [Fact]
+    public async Task SendAsync_RewritesNullToolCallArgumentsToEmptyObject()
+    {
+        var captured = new CapturingHandler();
+        var handler = new LoggingHttpHandler(captured);
+        using var client = new HttpClient(handler);
+
+        var body = """
+            {
+              "messages": [
+                {
+                  "role": "assistant",
+                  "tool_calls": [
+                    {
+                      "id": "call_1",
+                      "function": {
+                        "name": "ReadCatalog",
+                        "arguments": "null"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test/v1/chat/completions")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+
+        await client.SendAsync(request);
+
+        Assert.NotNull(captured.LastBody);
+        var root = JsonNode.Parse(captured.LastBody)!;
+        var arguments = root["messages"]![0]!["tool_calls"]![0]!["function"]!["arguments"]!.GetValue<string>();
+        Assert.Equal("{}", arguments);
+    }
+
+    [Fact]
+    public async Task SendAsync_DoesNotRewriteLiteralArgumentsNullInsideDocumentContent()
+    {
+        var captured = new CapturingHandler();
+        var handler = new LoggingHttpHandler(captured);
+        using var client = new HttpClient(handler);
+
+        var body = """
+            {
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "example payload contains \"arguments\":\"null\" in the document"
+                },
+                {
+                  "role": "assistant",
+                  "tool_calls": [
+                    {
+                      "id": "call_1",
+                      "function": {
+                        "name": "WriteDoc",
+                        "arguments": "{\"content\":\"the text arguments:\\\"null\\\" stays\"}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test/v1/chat/completions")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+
+        await client.SendAsync(request);
+
+        Assert.NotNull(captured.LastBody);
+        var root = JsonNode.Parse(captured.LastBody)!;
+        var userContent = root["messages"]![0]!["content"]!.GetValue<string>();
+        var writeArguments = root["messages"]![1]!["tool_calls"]![0]!["function"]!["arguments"]!.GetValue<string>();
+
+        Assert.Contains("\"arguments\":\"null\"", userContent, StringComparison.Ordinal);
+        Assert.Contains("the text arguments:", writeArguments, StringComparison.Ordinal);
+        Assert.Contains("null", writeArguments, StringComparison.Ordinal);
+        Assert.NotEqual("{}", writeArguments);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public string? LastBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastBody = request.Content == null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Normalize `messages[].tool_calls[].function.arguments` that are null, JSON null, empty, or the string `"null"` to `"{}"` before the chat request is sent.
- Mutate the JSON DOM field-by-field so document/catalog content that happens to contain the literal text `"arguments":"null"` is not rewritten.
- This keeps zero-argument tools (e.g. `ReadCatalog`) valid for strict JSON chat backends, not only OpenAI-compatible ones.

## Test plan
- [ ] `dotnet test tests/OpenDeepWiki.Tests/OpenDeepWiki.Tests.csproj --filter LoggingHttpHandlerTests`
- [ ] Incremental wiki update that calls a zero-argument tool should no longer 500 on providers that reject `"arguments":"null"`
- [ ] Confirm a document body containing the literal text `"arguments":"null"` is unchanged