### PR TITLE
fix(admin): clear nested DocCatalog parents before repository delete

### DIFF
--- a/src/OpenDeepWiki/Services/Admin/AdminRepositoryService.cs
+++ b/src/OpenDeepWiki/Services/Admin/AdminRepositoryService.cs
@@ -225,6 +225,26 @@ public class AdminRepositoryService : IAdminRepositoryService
 
         var repositoryIdArray = repositoryIds.Distinct().ToArray();
 
+        var branchLanguageIds = await (
+            from branch in _context.RepositoryBranches
+            where repositoryIdArray.Contains(branch.RepositoryId)
+            join language in _context.BranchLanguages on branch.Id equals language.RepositoryBranchId
+            select language.Id)
+            .Distinct()
+            .ToListAsync();
+
+        if (branchLanguageIds.Count > 0)
+        {
+            var catalogs = await _context.DocCatalogs
+                .Where(catalog => catalog.ParentId != null && branchLanguageIds.Contains(catalog.BranchLanguageId))
+                .ToListAsync();
+
+            foreach (var catalog in catalogs)
+            {
+                catalog.ParentId = null;
+            }
+        }
+
         var tokenUsages = await _context.TokenUsages
             .Where(usage => usage.RepositoryId != null && repositoryIdArray.Contains(usage.RepositoryId))
             .ToListAsync();

--- a/tests/OpenDeepWiki.Tests/OpenDeepWiki.Tests.csproj
+++ b/tests/OpenDeepWiki.Tests/OpenDeepWiki.Tests.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Sinks.File" />
   </ItemGroup>

--- a/tests/OpenDeepWiki.Tests/Services/Repositories/RepositorySourceSubmitTests.cs
+++ b/tests/OpenDeepWiki.Tests/Services/Repositories/RepositorySourceSubmitTests.cs
@@ -355,6 +355,97 @@ public class RepositorySourceSubmitTests
     }
 
     [Fact]
+    public async Task DeleteRepositoryAsync_ShouldSoftDeleteRepositoryAndRemoveNestedCatalogsUsingSqliteForeignKeys()
+    {
+        await using var context = await CreateSqliteContextAsync();
+        const string userId = "user-1";
+        var repositoryId = Guid.NewGuid().ToString();
+        var branchId = Guid.NewGuid().ToString();
+        var languageId = Guid.NewGuid().ToString();
+        var docFileId = Guid.NewGuid().ToString();
+        var parentCatalogId = Guid.NewGuid().ToString();
+
+        context.Users.Add(new User
+        {
+            Id = userId,
+            Name = "Test User",
+            Email = "test@example.com"
+        });
+        context.Repositories.Add(new Repository
+        {
+            Id = repositoryId,
+            OwnerUserId = userId,
+            GitUrl = "https://github.com/demo/repo.git",
+            OrgName = "demo",
+            RepoName = "repo"
+        });
+        context.RepositoryBranches.Add(new RepositoryBranch
+        {
+            Id = branchId,
+            RepositoryId = repositoryId,
+            BranchName = "main"
+        });
+        context.BranchLanguages.Add(new BranchLanguage
+        {
+            Id = languageId,
+            RepositoryBranchId = branchId,
+            LanguageCode = "en",
+            IsDefault = true
+        });
+        context.DocFiles.Add(new DocFile
+        {
+            Id = docFileId,
+            BranchLanguageId = languageId,
+            Content = "Leaf content"
+        });
+        context.DocCatalogs.AddRange(
+            new DocCatalog
+            {
+                Id = parentCatalogId,
+                BranchLanguageId = languageId,
+                Path = "1-overview",
+                Title = "Overview"
+            },
+            new DocCatalog
+            {
+                Id = Guid.NewGuid().ToString(),
+                BranchLanguageId = languageId,
+                ParentId = parentCatalogId,
+                Path = "1-overview.1-intro",
+                Title = "Intro",
+                DocFileId = docFileId
+            });
+        context.TokenUsages.Add(new TokenUsage
+        {
+            Id = Guid.NewGuid().ToString(),
+            RepositoryId = repositoryId,
+            RecordedAt = DateTime.UtcNow
+        });
+        context.UserActivities.Add(new UserActivity
+        {
+            Id = Guid.NewGuid().ToString(),
+            UserId = userId,
+            RepositoryId = repositoryId,
+            ActivityType = UserActivityType.View,
+            Weight = 1
+        });
+        await context.SaveChangesAsync();
+
+        var adminService = CreateAdminService(context);
+
+        var deleted = await adminService.DeleteRepositoryAsync(repositoryId);
+
+        Assert.True(deleted);
+        Assert.True((await context.Repositories.SingleAsync(r => r.Id == repositoryId)).IsDeleted);
+        Assert.False(await context.RepositoryBranches.AnyAsync(b => b.RepositoryId == repositoryId));
+        Assert.False(await context.BranchLanguages.AnyAsync(l => l.RepositoryBranchId == branchId));
+        Assert.False(await context.DocCatalogs.AnyAsync(c => c.BranchLanguageId == languageId));
+        Assert.False(await context.DocFiles.AnyAsync(f => f.BranchLanguageId == languageId));
+        Assert.Null((await context.TokenUsages.SingleAsync()).RepositoryId);
+        Assert.Null((await context.UserActivities.SingleAsync()).RepositoryId);
+    }
+
+    [Fact]
     public async Task SubmitAsync_ShouldRemoveSoftDeletedDuplicateBeforeRecreate()
     {
         using var context = CreateContext();
@@ -823,6 +914,18 @@ public class RepositorySourceSubmitTests
             .Options;
 
         return new TestDbContext(options);
+    }
+
+    private static async Task<TestDbContext> CreateSqliteContextAsync()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlite("Data Source=:memory:")
+            .Options;
+
+        var context = new TestDbContext(options);
+        await context.Database.OpenConnectionAsync();
+        await context.Database.EnsureCreatedAsync();
+        return context;
     }
 
     private static string CreateTempDirectory()


### PR DESCRIPTION
## Summary
- Nullify `DocCatalog.ParentId` before hard-deleting catalog rows during repository delete.
- The self-referential FK uses `OnDelete(Restrict)`, so nested catalogs fail on SQLite (and can fail on Postgres) even though the repository itself is only soft-deleted.
- Add a SQLite integration test that deletes a repository with a parent/child catalog tree.

## Test plan
- [ ] `dotnet test tests/OpenDeepWiki.Tests/OpenDeepWiki.Tests.csproj --filter DeleteRepositoryAsync_ShouldSoftDelete`
- [ ] In admin, delete a repository that has nested wiki catalogs and confirm it succeeds
- [ ] Confirm the repository row is soft-deleted and catalog/branch/file rows are removed